### PR TITLE
Use Travis-CI on both Linux and OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,280 @@
 language: cpp
-
-os:
-  - linux
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - boost-latest
-      - george-edison55-precise-backports
-    packages:
-      - cmake
-      - cmake-data
-#      - gdb
-      - gcc-4.9
-      - g++-4.9
-      - gfortran-4.9
-      - liblapack-dev
-#      - libboost1.55-all-dev
-      - libboost-filesystem1.55-dev
-      - libboost-chrono1.55-dev
-      - libboost-system1.55-dev
-      - libboost-timer1.55-dev
-      - libboost-python1.55-dev
-
+sudo: false
+matrix:
+  include:
+  - os: linux
+    compiler: clang
+    addons: &1
+      apt:
+        sources:
+        - llvm-toolchain-precise-3.5
+        - ubuntu-toolchain-r-test
+        - boost-latest
+        - george-edison55-precise-backports
+        packages:
+        - cmake
+        - cmake-data
+        - liblapack-dev
+        - clang-3.5
+        - libboost-filesystem1.55-dev
+        - libboost-chrono1.55-dev
+        - libboost-system1.55-dev
+        - libboost-timer1.55-dev
+        - libboost-python1.55-dev
+        - gfortran
+    env: CXX_COMPILER='clang++-3.5' C_COMPILER='clang-3.5' Fortran_COMPILER='gfortran' BUILD_TYPE='release'
+  - os: linux
+    compiler: clang
+    addons: *1
+    env: CXX_COMPILER='clang++-3.5' C_COMPILER='clang-3.5' Fortran_COMPILER='gfortran' BUILD_TYPE='debug'
+  - os: linux
+    compiler: clang
+    addons: &2
+      apt:
+        sources:
+        - llvm-toolchain-precise-3.6
+        - ubuntu-toolchain-r-test
+        - boost-latest
+        - george-edison55-precise-backports
+        packages:
+        - cmake
+        - cmake-data
+        - liblapack-dev
+        - clang-3.6
+        - libboost-filesystem1.55-dev
+        - libboost-chrono1.55-dev
+        - libboost-system1.55-dev
+        - libboost-timer1.55-dev
+        - libboost-python1.55-dev
+        - gfortran
+    env: CXX_COMPILER='clang++-3.6' C_COMPILER='clang-3.6' Fortran_COMPILER='gfortran' BUILD_TYPE='release'
+  - os: linux
+    compiler: clang
+    addons: *2
+    env: CXX_COMPILER='clang++-3.6' C_COMPILER='clang-3.6' Fortran_COMPILER='gfortran' BUILD_TYPE='debug'
+  - os: linux
+    compiler: clang
+    addons: &3
+      apt:
+        sources:
+        - llvm-toolchain-precise-3.7
+        - ubuntu-toolchain-r-test
+        - boost-latest
+        - george-edison55-precise-backports
+        packages:
+        - cmake
+        - cmake-data
+        - liblapack-dev
+        - clang-3.7
+        - libboost-filesystem1.55-dev
+        - libboost-chrono1.55-dev
+        - libboost-system1.55-dev
+        - libboost-timer1.55-dev
+        - libboost-python1.55-dev
+        - gfortran
+    env: CXX_COMPILER='clang++-3.7' C_COMPILER='clang-3.7' Fortran_COMPILER='gfortran' BUILD_TYPE='release'
+  - os: linux
+    compiler: clang
+    addons: *3
+    env: CXX_COMPILER='clang++-3.7' C_COMPILER='clang-3.7' Fortran_COMPILER='gfortran' BUILD_TYPE='debug'
+  - os: linux
+    compiler: clang
+    addons: &4
+      apt:
+        sources:
+        - llvm-toolchain-precise
+        - ubuntu-toolchain-r-test
+        - boost-latest
+        - george-edison55-precise-backports
+        packages:
+        - cmake
+        - cmake-data
+        - liblapack-dev
+        - clang-3.8
+        - libboost-filesystem1.55-dev
+        - libboost-chrono1.55-dev
+        - libboost-system1.55-dev
+        - libboost-timer1.55-dev
+        - libboost-python1.55-dev
+        - gfortran
+    env: CXX_COMPILER='clang++-3.8' C_COMPILER='clang-3.8' Fortran_COMPILER='gfortran' BUILD_TYPE='release'
+  - os: linux
+    compiler: clang
+    addons: *4
+    env: CXX_COMPILER='clang++-3.8' C_COMPILER='clang-3.8' Fortran_COMPILER='gfortran' BUILD_TYPE='debug'
+  - os: linux
+    compiler: gcc
+    addons: &5
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        - boost-latest
+        - george-edison55-precise-backports
+        packages:
+        - cmake
+        - cmake-data
+        - liblapack-dev
+        - g++-4.6
+        - gcc-4.6
+        - libboost-filesystem1.55-dev
+        - libboost-chrono1.55-dev
+        - libboost-system1.55-dev
+        - libboost-timer1.55-dev
+        - libboost-python1.55-dev
+        - gfortran-4.6
+    env: CXX_COMPILER='g++-4.6' C_COMPILER='gcc-4.6' Fortran_COMPILER='gfortran-4.6' BUILD_TYPE='release'
+  - os: linux
+    compiler: gcc
+    addons: *5
+    env: CXX_COMPILER='g++-4.6' C_COMPILER='gcc-4.6' Fortran_COMPILER='gfortran-4.6' BUILD_TYPE='debug'
+  - os: linux
+    compiler: gcc
+    addons: &6
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        - boost-latest
+        - george-edison55-precise-backports
+        packages:
+        - cmake
+        - cmake-data
+        - liblapack-dev
+        - g++-4.7
+        - gcc-4.7
+        - libboost-filesystem1.55-dev
+        - libboost-chrono1.55-dev
+        - libboost-system1.55-dev
+        - libboost-timer1.55-dev
+        - libboost-python1.55-dev
+        - gfortran-4.7
+    env: CXX_COMPILER='g++-4.7' C_COMPILER='gcc-4.7' Fortran_COMPILER='gfortran-4.7' BUILD_TYPE='release'
+  - os: linux
+    compiler: gcc
+    addons: *6
+    env: CXX_COMPILER='g++-4.7' C_COMPILER='gcc-4.7' Fortran_COMPILER='gfortran-4.7' BUILD_TYPE='debug'
+  - os: linux
+    compiler: gcc
+    addons: &7
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        - boost-latest
+        - george-edison55-precise-backports
+        packages:
+        - cmake
+        - cmake-data
+        - liblapack-dev
+        - g++-4.8
+        - gcc-4.8
+        - libboost-filesystem1.55-dev
+        - libboost-chrono1.55-dev
+        - libboost-system1.55-dev
+        - libboost-timer1.55-dev
+        - libboost-python1.55-dev
+        - gfortran-4.8
+    env: CXX_COMPILER='g++-4.8' C_COMPILER='gcc-4.8' Fortran_COMPILER='gfortran-4.8' BUILD_TYPE='release'
+  - os: linux
+    compiler: gcc
+    addons: *7
+    env: CXX_COMPILER='g++-4.8' C_COMPILER='gcc-4.8' Fortran_COMPILER='gfortran-4.8' BUILD_TYPE='debug'
+  - os: linux
+    compiler: gcc
+    addons: &8
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        - boost-latest
+        - george-edison55-precise-backports
+        packages:
+        - cmake
+        - cmake-data
+        - liblapack-dev
+        - g++-4.9
+        - gcc-4.9
+        - libboost-filesystem1.55-dev
+        - libboost-chrono1.55-dev
+        - libboost-system1.55-dev
+        - libboost-timer1.55-dev
+        - libboost-python1.55-dev
+        - gfortran-4.9
+    env: CXX_COMPILER='g++-4.9' C_COMPILER='gcc-4.9' Fortran_COMPILER='gfortran-4.9' BUILD_TYPE='release'
+  - os: linux
+    compiler: gcc
+    addons: *8
+    env: CXX_COMPILER='g++-4.9' C_COMPILER='gcc-4.9' Fortran_COMPILER='gfortran-4.9' BUILD_TYPE='debug'
+  - os: linux
+    compiler: gcc
+    addons: &9
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        - boost-latest
+        - george-edison55-precise-backports
+        packages:
+        - cmake
+        - cmake-data
+        - liblapack-dev
+        - g++-5
+        - gcc-5
+        - libboost-filesystem1.55-dev
+        - libboost-chrono1.55-dev
+        - libboost-system1.55-dev
+        - libboost-timer1.55-dev
+        - libboost-python1.55-dev
+        - gfortran-5
+    env: CXX_COMPILER='g++-5' C_COMPILER='gcc-5' Fortran_COMPILER='gfortran-5' BUILD_TYPE='release'
+  - os: linux
+    compiler: gcc
+    addons: *9
+    env: CXX_COMPILER='g++-5' C_COMPILER='gcc-5' Fortran_COMPILER='gfortran-5' BUILD_TYPE='debug'
+  - os: osx
+    osx_image: xcode6.4
+    compiler: clang
+    env: CXX_COMPILER='clang++' C_COMPILER='clang' Fortran_COMPILER='gfortran' BUILD_TYPE='debug'
+  - os: osx
+    osx_image: xcode6.4
+    compiler: clang
+    env: CXX_COMPILER='clang++' C_COMPILER='clang' Fortran_COMPILER='gfortran' BUILD_TYPE='release'
+  - os: osx
+    osx_image: xcode7
+    compiler: clang
+    env: CXX_COMPILER='clang++' C_COMPILER='clang' Fortran_COMPILER='gfortran' BUILD_TYPE='debug'
+  - os: osx
+    osx_image: xcode7
+    compiler: clang
+    env: CXX_COMPILER='clang++' C_COMPILER='clang' Fortran_COMPILER='gfortran' BUILD_TYPE='release'
+  - os: osx
+    osx_image: xcode6.4
+    compiler: gcc
+    env: CXX_COMPILER='g++-5' C_COMPILER='gcc-5' Fortran_COMPILER='gfortran' BUILD_TYPE='debug'
+  - os: osx
+    osx_image: xcode6.4
+    compiler: gcc
+    env: CXX_COMPILER='g++-5' C_COMPILER='gcc-5' Fortran_COMPILER='gfortran' BUILD_TYPE='release'
+  - os: osx
+    osx_image: xcode7
+    compiler: gcc
+    env: CXX_COMPILER='g++-5' C_COMPILER='gcc-5' Fortran_COMPILER='gfortran' BUILD_TYPE='debug'
+  - os: osx
+    osx_image: xcode7
+    compiler: gcc
+    env: CXX_COMPILER='g++-5' C_COMPILER='gcc-5' Fortran_COMPILER='gfortran' BUILD_TYPE='release'
+install:
+- DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
+- mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
+- |
+  if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+    brew install cmake python gcc
+    brew install boost --with-python
+    brew install boost-python
+  fi
+before_script:
+- cd ${TRAVIS_BUILD_DIR}
+- export CXX=${CXX_COMPILER}
+- export CC=${C_COMPILER}
+- export FC=${Fortran_COMPILER}
+- python setup --cxx=${CXX_COMPILER} --cc=${C_COMPILER} --fc=${Fortran_COMPITER} --type=${BUILD_TYPE} objdir
+- cd objdir
 script:
-  - mkdir objdir && cd objdir && ../setup --cxx=g++-4.9 --fc=gfortran-4.9 --cc=gcc-4.9 && make
+- VERBOSE=1 make -j 2
+- ctest -V -j 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,8 @@ add_subdirectory(include)
 add_subdirectory(src)
 
 # test suite
+enable_testing()
+include(CTest)
 add_subdirectory(test)
 
 # sample suite

--- a/README.md
+++ b/README.md
@@ -2,3 +2,36 @@
 C++ library for the implementation of tensor product calculations through a clean, concise user interface.
 
 Build status: [![Build Status](https://travis-ci.org/jturney/ambit.svg?branch=master)](https://travis-ci.org/jturney/ambit)
+
+Primary test environments
+=========================
+
+Continuous integration builds
+-----------------------------
+
+- Ubuntu 12.04 LTS 64-bit with Python 2.7.3, CMake 3.3.2 and Boost 1.55.0
+  this is the environment offered by [Travis CI](https://travis-ci.org) pulling
+  in various PPA. The following compilers are used, both in release and debug:
+
+  1. GCC 4.6
+  2. GCC 4.7
+  3. GCC 4.8
+  4. GCC 4.9
+  5. GCC 5.1, with and without coverage analysis in debug mode
+  6. Clang 3.5 and GFortran 4.6
+  7. Clang 3.6 and GFortran 4.6
+  8. Clang 3.7 and GFortran 4.6
+  9. Clang 3.8 and GFortran 4.6
+
+- Mac OS X 10.9.5 with Python 2.7.10, CMake 3.2.3 and Boost 1.58.0
+  this is the environment offered by [Travis CI](https://travis-ci.org)
+  The following compilers are used, both in release and debug:
+
+  1. XCode 6.4 with Clang and GFortran 5.2
+  2. XCode 6.4 with GCC 5.2
+  3. XCode 7.0 with Clang and GFortran 5.2
+  4. XCode 7.0 with GCC 5.2
+
+Nightly builds
+--------------
+

--- a/include/ambit/io/file.h
+++ b/include/ambit/io/file.h
@@ -20,6 +20,7 @@
 #define TENSOR_IO_FILE
 
 #include <cstdint>
+#include <stdexcept>
 #include <string>
 #include <vector>
 #include <functional>

--- a/src/blocked_tensor/blocked_tensor.cc
+++ b/src/blocked_tensor/blocked_tensor.cc
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <stdexcept>
 #include <string>
 #include <algorithm>
 #include <ambit/blocked_tensor.h>

--- a/src/helpers/psi4/integrals.cc
+++ b/src/helpers/psi4/integrals.cc
@@ -2,6 +2,8 @@
 // Created by Justin Turney on 12/17/15.
 //
 
+#include <stdexcept>
+
 #include <ambit/helpers/psi4/integrals.h>
 #include <ambit/tensor.h>
 #include <tensor/core/core.h>

--- a/src/tensor/core/core.cc
+++ b/src/tensor/core/core.cc
@@ -3,6 +3,7 @@
 #include "tensor/indices.h"
 #include <ambit/timer.h>
 #include <algorithm>
+#include <stdexcept>
 #include <string.h>
 #include <cmath>
 #include <limits>

--- a/src/tensor/cyclops/cyclops.cc
+++ b/src/tensor/cyclops/cyclops.cc
@@ -2,6 +2,8 @@
 #error The Cyclops interface is being compiled without Cyclops present.
 #endif
 
+#include <stdexcept>
+
 #include "cyclops.h"
 #include "../globals.h"
 #include <ambit/print.h>

--- a/src/tensor/indices.cc
+++ b/src/tensor/indices.cc
@@ -1,6 +1,7 @@
 #include <ambit/common_types.h>
 
 #include <algorithm>
+#include <stdexcept>
 #include "indices.h"
 
 namespace ambit

--- a/src/tensor/sliced_tensor.cc
+++ b/src/tensor/sliced_tensor.cc
@@ -1,3 +1,4 @@
+#include <stdexcept>
 #include <ambit/tensor.h>
 
 namespace ambit

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_OPERATORS_SOURCES
 add_executable(test_operators ${TEST_OPERATORS_SOURCES})
 add_dependencies(test_operators ambit)
 target_link_libraries(test_operators ambit ${Boost_LIBRARIES})
+add_test(NAME operators COMMAND test_operators)
 
 set(TEST_CORE_SOURCES
     test_core.cc
@@ -15,6 +16,7 @@ set(TEST_CORE_SOURCES
 add_executable(test_core ${TEST_CORE_SOURCES})
 add_dependencies(test_core ambit)
 target_link_libraries(test_core ambit ${Boost_LIBRARIES})
+add_test(NAME core COMMAND test_core)
 
 if(ENABLE_CYCLOPS)
     set(TEST_CYCLOPS_SOURCES
@@ -24,6 +26,7 @@ if(ENABLE_CYCLOPS)
     add_executable(test_cyclops ${TEST_CYCLOPS_SOURCES})
     add_dependencies(test_cyclops ambit)
     target_link_libraries(test_cyclops ambit ${Boost_LIBRARIES})
+    add_test(NAME cyclops COMMAND test_cyclops)
 
     set(TEST_DISTRIBUTED_SOURCES
         test_distributed.cc
@@ -32,6 +35,7 @@ if(ENABLE_CYCLOPS)
     add_executable(test_distributed ${TEST_DISTRIBUTED_SOURCES})
     add_dependencies(test_distributed ambit)
     target_link_libraries(test_distributed ambit ${Boost_LIBRARIES})
+    add_test(NAME distributed COMMAND test_distributed)
 endif()
 
 set(TEST_HF_SOURCES
@@ -42,6 +46,7 @@ set(TEST_HF_SOURCES
 add_executable(test_hf ${TEST_HF_SOURCES})
 add_dependencies(test_hf ambit)
 target_link_libraries(test_hf ambit ${Boost_LIBRARIES})
+add_test(NAME hf COMMAND test_hf)
 
 set(TEST_BLOCKS_SOURCES
     test_blocks.cc
@@ -51,10 +56,12 @@ set(TEST_BLOCKS_SOURCES
 add_executable(test_blocks ${TEST_BLOCKS_SOURCES})
 add_dependencies(test_blocks ambit)
 target_link_libraries(test_blocks ambit ${Boost_LIBRARIES})
+add_test(NAME blocks COMMAND test_blocks)
 
 add_executable(test_performance test_performance.cc)
 add_dependencies(test_performance ambit)
 target_link_libraries(test_performance ambit ${Boost_LIBRARIES})
+add_test(NAME performance COMMAND test_performance)
 
 configure_file(test.32 test.32 COPYONLY)
 configure_file(test.33 test.33 COPYONLY)

--- a/test/test_blocks.cc
+++ b/test/test_blocks.cc
@@ -1,6 +1,7 @@
 #include <ambit/blocked_tensor.h>
 #include <cmath>
 #include <cstdlib>
+#include <stdexcept>
 
 #define ANSI_COLOR_RED "\x1b[31m"
 #define ANSI_COLOR_GREEN "\x1b[32m"

--- a/test/test_core.cc
+++ b/test/test_core.cc
@@ -1,6 +1,7 @@
 #include <ambit/tensor.h>
 #include <cmath>
 #include <cstdlib>
+#include <stdexcept>
 
 #define ANSI_COLOR_RED "\x1b[31m"
 #define ANSI_COLOR_GREEN "\x1b[32m"

--- a/test/test_cyclops.cc
+++ b/test/test_cyclops.cc
@@ -1,6 +1,7 @@
 #include <ambit/tensor.h>
 #include <cmath>
 #include <cstdlib>
+#include <stdexcept>
 
 #define ANSI_COLOR_RED "\x1b[31m"
 #define ANSI_COLOR_GREEN "\x1b[32m"

--- a/test/test_distributed.cc
+++ b/test/test_distributed.cc
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <assert.h>
 #include <cstdlib>
+#include <stdexcept>
 
 #define ANSI_COLOR_RED "\x1b[31m"
 #define ANSI_COLOR_GREEN "\x1b[32m"

--- a/test/test_hf.cc
+++ b/test/test_hf.cc
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <assert.h>
+#include <stdexcept>
 
 #include <ambit/print.h>
 #include <ambit/tensor.h>

--- a/test/test_operators.cc
+++ b/test/test_operators.cc
@@ -4,6 +4,7 @@
 //#include <cstdio>
 #include <cmath>
 //#include <utility>
+#include <stdexcept>
 
 #define MAXTWO 10
 #define MAXFOUR 10

--- a/test/test_performance.cc
+++ b/test/test_performance.cc
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <assert.h>
+#include <stdexcept>
 
 #include <ambit/print.h>
 #include <ambit/tensor.h>


### PR DESCRIPTION
The `.travis.yml` file uses different compiler versions on both Linux and OS X. Debug and release configurations are tested. In total 26 builds are run on each push to the master branch. I have updated the `README.md` file to document the test environments used. GCC 4.6 might be too old a compiler for this project: the builds are crashing with an error that I think it's related to template aliases.