### PR TITLE
allow passed-in HDF5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,11 @@ find_package(Threads REQUIRED)
 link_libraries("${CMAKE_THREAD_LIBS_INIT}")
 
 # HDF5 detection
-find_package(HDF5 REQUIRED)
+if (HDF5_LIBRARIES AND HDF5_INCLUDE_DIRS)
+    message(STATUS "HDF5 detection suppressed. Using: ${HDF5_LIBRARIES} and includes ${HDF5_INCLUDE_DIRS}")
+else (HDF5_LIBRARIES AND HDF5_INCLUDE_DIRS)
+    find_package (HDF5 REQUIRED)
+endif (HDF5_LIBRARIES AND HDF5_INCLUDE_DIRS)
 include_directories(SYSTEM ${HDF5_INCLUDE_DIRS})
 
 # Python Detection


### PR DESCRIPTION
This is a measly PR, but it's the only part of my effort to put together an ambit conda package that worked, so may as well merge it. Other end of passing libraries from psi4 is already in place (PR submitted).