### PR TITLE
cmake patches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,37 +34,36 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 # <<<  CMake includes  >>>
 
-include (GNUInstallDirs)
 include (CheckCXXCompilerFlag)
 include (CMakePackageConfigHelpers)
 
 # <<<  Default CMake options  >>>
 include(psi4OptionsTools)
 
-option_with_default(CMAKE_BUILD_TYPE "Build type" Release)
-option_with_print(BUILD_SHARED_LIBS "Build final library as shared, not static" OFF)
+option_with_default(CMAKE_BUILD_TYPE "Build type (Release or Debug)" Release)
+#option_with_print(BUILD_SHARED_LIBS "Build final library as shared, not static" OFF)
 #option_with_default(BUILD_FPIC "Libraries will be compiled with position independent code" ON)
 #if(${BUILD_SHARED_LIBS} AND NOT ${BUILD_FPIC})
 #    message(FATAL_ERROR "BUILD_SHARED_LIBS ON and BUILD_FPIC OFF are incompatible, as shared library requires position independent code")
 #endif()
-option_with_print(ENABLE_OPENMP "Enable OpenMP parallelization. Psi4 wants OFF" OFF)
-option_with_print(ENABLE_GENERIC "Enable mostly static linking in shared library" OFF)
-option_with_flags(ENABLE_XHOST "Enable processor-specific optimization" ON
-        "-xHost" "-march=native")
 
 option (BUILD_DOXYGEN        "Use Doxygen to create a HTML/PDF manual" OFF)
 option (BUILD_SPHINX         "Build the user manual with Sphinx"       OFF)
 option (STATIC_ONLY          "Compile only the static library"         OFF)
 option (SHARED_ONLY          "Compile only the shared library"         OFF)
 option (ENABLE_TESTS         "Compile the tests"                       ON)
-#option (ENABLE_XHOST         "Enable processor-specific optimizations" ON)
-#option (ENABLE_GENERIC       "Enable mostly static linking in shared library" OFF)
-#option (ENABLE_OPENMP        "Enable OpenMP parallelization"           ON)
 option (WITH_MPI             "Build the library with MPI"              OFF)
 option (ENABLE_CYCLOPS       "Enable Cyclops usage" OFF)
 option (BUILD_FPIC           "Static library in STATIC_ONLY will be compiled with position independent code" ON)
 option (CYCLOPS              "Location of the Cyclops build directory" "")
 option (ELEMENTAL            "Location of the Elemental build directory" "")
+option_with_print(ENABLE_OPENMP "Enable OpenMP parallelization" ON)
+option_with_flags(ENABLE_XHOST "Enables processor-specific optimization" ON
+                  "-xHost" "-march=native")
+option_with_default(FC_SYMBOL "The type of Fortran name mangling" 2)
+option_with_default(BUILD_FPIC "Compile static libraries with position independent code" ON)
+option_with_default(CMAKE_INSTALL_LIBDIR "Directory to which libraries installed" lib)
+option_with_default(ENABLE_GENERIC "Enables mostly static linking of system and math libraries for shared library" OFF)
 
 ########################  Process & Validate Options  ##########################
 include(GNUInstallDirs)
@@ -91,6 +90,10 @@ include_directories(SYSTEM $<TARGET_PROPERTY:tgt::hdf5,INTERFACE_INCLUDE_DIRECTO
 find_package (TargetLAPACK REQUIRED)
 
 # Python Detection
+set(Python_ADDITIONAL_VERSIONS 3.7 3.6 3.5)  # adjust with CMake minimum FindPythonInterp
+find_package(PythonLibsNew REQUIRED)
+message(STATUS "Found Python ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}: ${PYTHON_EXECUTABLE} (found version ${PYTHON_VERSION_STRING})")
+
 #if (NOT ENABLE_STATIC AND NOT ENABLE_PSI4)
 #    include(ConfigPython)
 #    link_libraries("${PYTHON_LIBRARIES}")
@@ -147,7 +150,6 @@ endif()
 add_subdirectory(lib)
 
 # include directory (for installation)
-#include(GNUInstallDirs)
 add_subdirectory(include)
 
 # recursively add source directories
@@ -168,7 +170,7 @@ add_subdirectory(src)
 # <<<  Export Config  >>>
 
 include(CMakePackageConfigHelpers)
-# explicit "share" not "DATADIR" for CMake search path
+# GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
 set(CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}")
 configure_package_config_file(cmake/${PROJECT_NAME}Config.cmake.in
         "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
@@ -178,6 +180,7 @@ write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Conf
         COMPATIBILITY AnyNewerVersion)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+        cmake/FindTargetHDF5.cmake
         DESTINATION ${CMAKECONFIG_INSTALL_DIR})
 
 # this has to be the very last CMake module to be included

--- a/cmake/FindPythonLibsNew.cmake
+++ b/cmake/FindPythonLibsNew.cmake
@@ -1,0 +1,194 @@
+# - Find python libraries
+# This module finds the libraries corresponding to the Python interpeter
+# FindPythonInterp provides.
+# This code sets the following variables:
+#
+#  PYTHONLIBS_FOUND           - have the Python libs been found
+#  PYTHON_PREFIX              - path to the Python installation
+#  PYTHON_LIBRARIES           - path to the python library
+#  PYTHON_INCLUDE_DIRS        - path to where Python.h is found
+#  PYTHON_MODULE_EXTENSION    - lib extension, e.g. '.so' or '.pyd'
+#  PYTHON_MODULE_PREFIX       - lib name prefix: usually an empty string
+#  PYTHON_SITE_PACKAGES       - path to installation site-packages
+#  PYTHON_IS_DEBUG            - whether the Python interpreter is a debug build
+#
+# Thanks to talljimbo for the patch adding the 'LDVERSION' config
+# variable usage.
+
+#=============================================================================
+# Copyright 2001-2009 Kitware, Inc.
+# Copyright 2012 Continuum Analytics, Inc.
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# * Neither the names of Kitware, Inc., the Insight Software Consortium,
+# nor the names of their contributors may be used to endorse or promote
+# products derived from this software without specific prior written
+# permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# # A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#=============================================================================
+
+if(PYTHONLIBS_FOUND)
+    return()
+endif()
+
+# Use the Python interpreter to find the libs.
+if(PythonLibsNew_FIND_REQUIRED)
+    find_package(PythonInterp ${PythonLibsNew_FIND_VERSION} REQUIRED)
+else()
+    find_package(PythonInterp ${PythonLibsNew_FIND_VERSION})
+endif()
+
+if(NOT PYTHONINTERP_FOUND)
+    set(PYTHONLIBS_FOUND FALSE)
+    return()
+endif()
+
+# According to http://stackoverflow.com/questions/646518/python-how-to-detect-debug-interpreter
+# testing whether sys has the gettotalrefcount function is a reliable, cross-platform
+# way to detect a CPython debug interpreter.
+#
+# The library suffix is from the config var LDVERSION sometimes, otherwise
+# VERSION. VERSION will typically be like "2.7" on unix, and "27" on windows.
+execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+    "from distutils import sysconfig as s;import sys;import struct;
+print('.'.join(str(v) for v in sys.version_info));
+print(sys.prefix);
+print(s.get_python_inc(plat_specific=True));
+print(s.get_python_lib(plat_specific=True));
+print(s.get_config_var('SO'));
+print(hasattr(sys, 'gettotalrefcount')+0);
+print(struct.calcsize('@P'));
+print(s.get_config_var('LDVERSION') or s.get_config_var('VERSION'));
+print(s.get_config_var('LIBDIR') or '');
+print(s.get_config_var('MULTIARCH') or '');
+"
+    RESULT_VARIABLE _PYTHON_SUCCESS
+    OUTPUT_VARIABLE _PYTHON_VALUES
+    ERROR_VARIABLE _PYTHON_ERROR_VALUE)
+
+if(NOT _PYTHON_SUCCESS MATCHES 0)
+    if(PythonLibsNew_FIND_REQUIRED)
+        message(FATAL_ERROR
+            "Python config failure:\n${_PYTHON_ERROR_VALUE}")
+    endif()
+    set(PYTHONLIBS_FOUND FALSE)
+    return()
+endif()
+
+# Convert the process output into a list
+string(REGEX REPLACE ";" "\\\\;" _PYTHON_VALUES ${_PYTHON_VALUES})
+string(REGEX REPLACE "\n" ";" _PYTHON_VALUES ${_PYTHON_VALUES})
+list(GET _PYTHON_VALUES 0 _PYTHON_VERSION_LIST)
+list(GET _PYTHON_VALUES 1 PYTHON_PREFIX)
+list(GET _PYTHON_VALUES 2 PYTHON_INCLUDE_DIR)
+list(GET _PYTHON_VALUES 3 PYTHON_SITE_PACKAGES)
+list(GET _PYTHON_VALUES 4 PYTHON_MODULE_EXTENSION)
+list(GET _PYTHON_VALUES 5 PYTHON_IS_DEBUG)
+list(GET _PYTHON_VALUES 6 PYTHON_SIZEOF_VOID_P)
+list(GET _PYTHON_VALUES 7 PYTHON_LIBRARY_SUFFIX)
+list(GET _PYTHON_VALUES 8 PYTHON_LIBDIR)
+list(GET _PYTHON_VALUES 9 PYTHON_MULTIARCH)
+
+# Make sure the Python has the same pointer-size as the chosen compiler
+# Skip if CMAKE_SIZEOF_VOID_P is not defined
+if(CMAKE_SIZEOF_VOID_P AND (NOT "${PYTHON_SIZEOF_VOID_P}" STREQUAL "${CMAKE_SIZEOF_VOID_P}"))
+    if(PythonLibsNew_FIND_REQUIRED)
+        math(EXPR _PYTHON_BITS "${PYTHON_SIZEOF_VOID_P} * 8")
+        math(EXPR _CMAKE_BITS "${CMAKE_SIZEOF_VOID_P} * 8")
+        message(FATAL_ERROR
+            "Python config failure: Python is ${_PYTHON_BITS}-bit, "
+            "chosen compiler is  ${_CMAKE_BITS}-bit")
+    endif()
+    set(PYTHONLIBS_FOUND FALSE)
+    return()
+endif()
+
+# The built-in FindPython didn't always give the version numbers
+string(REGEX REPLACE "\\." ";" _PYTHON_VERSION_LIST ${_PYTHON_VERSION_LIST})
+list(GET _PYTHON_VERSION_LIST 0 PYTHON_VERSION_MAJOR)
+list(GET _PYTHON_VERSION_LIST 1 PYTHON_VERSION_MINOR)
+list(GET _PYTHON_VERSION_LIST 2 PYTHON_VERSION_PATCH)
+
+# Make sure all directory separators are '/'
+string(REGEX REPLACE "\\\\" "/" PYTHON_PREFIX ${PYTHON_PREFIX})
+string(REGEX REPLACE "\\\\" "/" PYTHON_INCLUDE_DIR ${PYTHON_INCLUDE_DIR})
+string(REGEX REPLACE "\\\\" "/" PYTHON_SITE_PACKAGES ${PYTHON_SITE_PACKAGES})
+
+if(CMAKE_HOST_WIN32)
+    set(PYTHON_LIBRARY
+        "${PYTHON_PREFIX}/libs/Python${PYTHON_LIBRARY_SUFFIX}.lib")
+
+    # when run in a venv, PYTHON_PREFIX points to it. But the libraries remain in the
+    # original python installation. They may be found relative to PYTHON_INCLUDE_DIR.
+    if(NOT EXISTS "${PYTHON_LIBRARY}")
+        get_filename_component(_PYTHON_ROOT ${PYTHON_INCLUDE_DIR} DIRECTORY)
+        set(PYTHON_LIBRARY
+            "${_PYTHON_ROOT}/libs/Python${PYTHON_LIBRARY_SUFFIX}.lib")
+    endif()
+
+    # raise an error if the python libs are still not found.
+    if(NOT EXISTS "${PYTHON_LIBRARY}")
+        message(FATAL_ERROR "Python libraries not found")
+    endif()
+
+else()
+    if(PYTHON_MULTIARCH)
+        set(_PYTHON_LIBS_SEARCH "${PYTHON_LIBDIR}/${PYTHON_MULTIARCH}" "${PYTHON_LIBDIR}")
+    else()
+        set(_PYTHON_LIBS_SEARCH "${PYTHON_LIBDIR}")
+    endif()
+    #message(STATUS "Searching for Python libs in ${_PYTHON_LIBS_SEARCH}")
+    # Probably this needs to be more involved. It would be nice if the config
+    # information the python interpreter itself gave us were more complete.
+    find_library(PYTHON_LIBRARY
+        NAMES "python${PYTHON_LIBRARY_SUFFIX}"
+        PATHS ${_PYTHON_LIBS_SEARCH}
+        NO_DEFAULT_PATH)
+
+    # If all else fails, just set the name/version and let the linker figure out the path.
+    if(NOT PYTHON_LIBRARY)
+        set(PYTHON_LIBRARY python${PYTHON_LIBRARY_SUFFIX})
+    endif()
+endif()
+
+MARK_AS_ADVANCED(
+  PYTHON_LIBRARY
+  PYTHON_INCLUDE_DIR
+)
+
+# We use PYTHON_INCLUDE_DIR, PYTHON_LIBRARY and PYTHON_DEBUG_LIBRARY for the
+# cache entries because they are meant to specify the location of a single
+# library. We now set the variables listed by the documentation for this
+# module.
+SET(PYTHON_INCLUDE_DIRS "${PYTHON_INCLUDE_DIR}")
+SET(PYTHON_LIBRARIES "${PYTHON_LIBRARY}")
+SET(PYTHON_DEBUG_LIBRARIES "${PYTHON_DEBUG_LIBRARY}")
+
+find_package_message(PYTHON
+    "Found PythonLibs: ${PYTHON_LIBRARY}"
+    "${PYTHON_EXECUTABLE}${PYTHON_VERSION}")
+
+set(PYTHONLIBS_FOUND TRUE)

--- a/cmake/FindTargetLAPACK.cmake
+++ b/cmake/FindTargetLAPACK.cmake
@@ -1,5 +1,5 @@
 # FindTargetLAPACK.cmake
-# --------------------
+# ----------------------
 #
 # LAPACK cmake module to wrap FindLAPACK.cmake in a target.
 #
@@ -11,8 +11,6 @@
 # This module *unsets* the following conventional LAPACK variables so as
 #   to force using the target: ::
 #
-#   BLAS_FOUND
-#   BLAS_LIBRARIES
 #   LAPACK_FOUND
 #   LAPACK_LIBRARIES
 #
@@ -25,9 +23,7 @@ if (LAPACK_LIBRARIES)
         message (STATUS "LAPACK detection suppressed.")
     endif()
 
-    add_library (tgt::blas INTERFACE IMPORTED)
     add_library (tgt::lapack INTERFACE IMPORTED)
-    set_property (TARGET tgt::blas PROPERTY INTERFACE_LINK_LIBRARIES ${LAPACK_LIBRARIES})
     set_property (TARGET tgt::lapack PROPERTY INTERFACE_LINK_LIBRARIES ${LAPACK_LIBRARIES})
 else()
     # 2nd precedence - target already prepared and findable in TargetLAPACKConfig.cmake
@@ -37,20 +33,16 @@ else()
             message (STATUS "TargetLAPACKConfig detected.")
         endif()
     else()
-        # 3rd precedence - usual variables from FindLAPACK.cmake or ConfigMath
-        include(ConfigMath)
+        # 3rd precedence - usual variables from FindLAPACK.cmake
+        find_package (LAPACK QUIET MODULE)
         if (NOT ${PN}_FIND_QUIETLY)
-            message (STATUS "ConfigMath LAPACK detected.")
+            message (STATUS "LAPACK detected.")
         endif()
     
-        add_library (tgt::blas INTERFACE IMPORTED)
-        add_library (tgt::lapk INTERFACE IMPORTED)
         add_library (tgt::lapack INTERFACE IMPORTED)
-        set_property (TARGET tgt::blas PROPERTY INTERFACE_LINK_LIBRARIES ${BLAS_LIBRARIES})
-        set_property (TARGET tgt::lapk PROPERTY INTERFACE_LINK_LIBRARIES ${LAPACK_LIBRARIES})
-        set_property (TARGET tgt::lapack PROPERTY INTERFACE_LINK_LIBRARIES lapk blas)
+        set_property (TARGET tgt::lapack PROPERTY INTERFACE_LINK_LIBRARIES ${LAPACK_LIBRARIES})
 
-        unset (BLAS_LIBRARIES)
+        unset (LAPACK_FOUND)
         unset (LAPACK_LIBRARIES)
     endif()
 endif()    

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,7 +96,8 @@ if (NOT SHARED_ONLY)
     target_link_libraries (ambit-static PUBLIC tgt::lapack
                                                 tgt::hdf5)
     set_target_properties (ambit-static PROPERTIES OUTPUT_NAME "ambit"
-                                                   EXPORT_NAME "ambit")
+                                                   EXPORT_NAME "ambit"
+                                                   POSITION_INDEPENDENT_CODE ${BUILD_FPIC})
 endif()
 
 # LAB: not addressed


### PR DESCRIPTION
Default in Psi4 is to build externals static, then that wasn't working b/c this repo wasn't building static with fpic.

Patches CMake to ...
* allow static+fpic
* install FindTargetHDF5.cmake
* use new Python detection
* kill off BUILD_SHARED_LIBS.