### PR TITLE
Efficient batched contraction.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ before_script:
 - export CC=${C_COMPILER}
 - |
   if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-    pyenv global 3.5
+    pyenv global 3.6
   fi
 - cmake -H. -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -Bobjdir
 - cd objdir

--- a/include/ambit/tensor.h
+++ b/include/ambit/tensor.h
@@ -350,6 +350,12 @@ class Tensor
     void contract(const Tensor &A, const Tensor &B, const Indices &Cinds,
                   const Indices &Ainds, const Indices &Binds,
                   double alpha = 1.0, double beta = 0.0);
+    void contract(const Tensor &A, const Tensor &B, const Indices &Cinds,
+                  const Indices &Ainds, const Indices &Binds,
+                  std::shared_ptr<TensorImpl> &A2,
+                  std::shared_ptr<TensorImpl> &B2,
+                  std::shared_ptr<TensorImpl> &C2,
+                  double alpha = 1.0, double beta = 0.0);
 
     /**
      * Perform the GEMM call equivalent to:

--- a/src/tensor/core/core.cc
+++ b/src/tensor/core/core.cc
@@ -37,6 +37,7 @@
 #include <string.h>
 #include <cmath>
 #include <limits>
+#include <iostream>
 
 //#include <boost/timer/timer.hpp>
 
@@ -167,9 +168,9 @@ void CoreTensorImpl::contract(ConstTensorImplPtr A, ConstTensorImplPtr B,
                               const Indices &Cinds, const Indices &Ainds,
                               const Indices &Binds, double alpha, double beta)
 {
-    shared_ptr<TensorImpl> C2;
-    shared_ptr<TensorImpl> B2;
     shared_ptr<TensorImpl> A2;
+    shared_ptr<TensorImpl> B2;
+    shared_ptr<TensorImpl> C2;
     contract(A, B, Cinds, Ainds, Binds, A2, B2, C2, alpha, beta);
 }
 
@@ -519,24 +520,27 @@ void CoreTensorImpl::contract(ConstTensorImplPtr A, ConstTensorImplPtr B,
     if (permC)
     {
         ambit::timer::timer_push("pre-BLAS: internal C allocation");
-        if (!C2)
+        if (!C2) {
             C2 = shared_ptr<CoreTensorImpl>(new CoreTensorImpl("C2", Cdims2));
+        }
         C2p = C2->data().data();
         ambit::timer::timer_pop();
     }
     if (permA)
     {
         ambit::timer::timer_push("pre-BLAS: internal A allocation");
-        if (!A2)
+        if (!A2) {
             A2 = shared_ptr<CoreTensorImpl>(new CoreTensorImpl("A2", Adims2));
+        }
         A2p = A2->data().data();
         ambit::timer::timer_pop();
     }
     if (permB)
     {
         ambit::timer::timer_push("pre-BLAS: internal B allocation");
-        if (!B2)
+        if (!B2) {
             B2 = shared_ptr<CoreTensorImpl>(new CoreTensorImpl("B2", Bdims2));
+        }
         B2p = B2->data().data();
         ambit::timer::timer_pop();
     }

--- a/src/tensor/core/core.cc
+++ b/src/tensor/core/core.cc
@@ -167,6 +167,20 @@ void CoreTensorImpl::contract(ConstTensorImplPtr A, ConstTensorImplPtr B,
                               const Indices &Cinds, const Indices &Ainds,
                               const Indices &Binds, double alpha, double beta)
 {
+    shared_ptr<TensorImpl> C2;
+    shared_ptr<TensorImpl> B2;
+    shared_ptr<TensorImpl> A2;
+    contract(A, B, Cinds, Ainds, Binds, A2, B2, C2, alpha, beta);
+}
+
+void CoreTensorImpl::contract(ConstTensorImplPtr A, ConstTensorImplPtr B,
+                              const Indices &Cinds, const Indices &Ainds,
+                              const Indices &Binds,
+                              std::shared_ptr<TensorImpl> &A2,
+                              std::shared_ptr<TensorImpl> &B2,
+                              std::shared_ptr<TensorImpl> &C2,
+                              double alpha, double beta)
+{
     ambit::timer::timer_push("pre-BLAS: internal overhead");
 
     TensorImplPtr C = this;
@@ -499,27 +513,30 @@ void CoreTensorImpl::contract(ConstTensorImplPtr A, ConstTensorImplPtr B,
     double *A2p = Ap;
     double *B2p = Bp;
 
-    shared_ptr<CoreTensorImpl> C2;
-    shared_ptr<CoreTensorImpl> B2;
-    shared_ptr<CoreTensorImpl> A2;
+//    shared_ptr<CoreTensorImpl> C2;
+//    shared_ptr<CoreTensorImpl> B2;
+//    shared_ptr<CoreTensorImpl> A2;
     if (permC)
     {
         ambit::timer::timer_push("pre-BLAS: internal C allocation");
-        C2 = shared_ptr<CoreTensorImpl>(new CoreTensorImpl("C2", Cdims2));
+        if (!C2)
+            C2 = shared_ptr<CoreTensorImpl>(new CoreTensorImpl("C2", Cdims2));
         C2p = C2->data().data();
         ambit::timer::timer_pop();
     }
     if (permA)
     {
         ambit::timer::timer_push("pre-BLAS: internal A allocation");
-        A2 = shared_ptr<CoreTensorImpl>(new CoreTensorImpl("A2", Adims2));
+        if (!A2)
+            A2 = shared_ptr<CoreTensorImpl>(new CoreTensorImpl("A2", Adims2));
         A2p = A2->data().data();
         ambit::timer::timer_pop();
     }
     if (permB)
     {
         ambit::timer::timer_push("pre-BLAS: internal B allocation");
-        B2 = shared_ptr<CoreTensorImpl>(new CoreTensorImpl("B2", Bdims2));
+        if (!B2)
+            B2 = shared_ptr<CoreTensorImpl>(new CoreTensorImpl("B2", Bdims2));
         B2p = B2->data().data();
         ambit::timer::timer_pop();
     }

--- a/src/tensor/core/core.cc
+++ b/src/tensor/core/core.cc
@@ -37,7 +37,6 @@
 #include <string.h>
 #include <cmath>
 #include <limits>
-#include <iostream>
 
 //#include <boost/timer/timer.hpp>
 
@@ -514,9 +513,6 @@ void CoreTensorImpl::contract(ConstTensorImplPtr A, ConstTensorImplPtr B,
     double *A2p = Ap;
     double *B2p = Bp;
 
-//    shared_ptr<CoreTensorImpl> C2;
-//    shared_ptr<CoreTensorImpl> B2;
-//    shared_ptr<CoreTensorImpl> A2;
     if (permC)
     {
         ambit::timer::timer_push("pre-BLAS: internal C allocation");

--- a/src/tensor/core/core.h
+++ b/src/tensor/core/core.h
@@ -67,6 +67,14 @@ class CoreTensorImpl : public TensorImpl
                   const Indices &Cinds, const Indices &Ainds,
                   const Indices &Binds, double alpha = 1.0, double beta = 0.0);
 
+    void contract(ConstTensorImplPtr A, ConstTensorImplPtr B,
+                  const Indices &Cinds, const Indices &Ainds,
+                  const Indices &Binds,
+                  std::shared_ptr<TensorImpl> &A2,
+                  std::shared_ptr<TensorImpl> &B2,
+                  std::shared_ptr<TensorImpl> &C2,
+                  double alpha = 1.0, double beta = 0.0);
+
     void gemm(ConstTensorImplPtr A, ConstTensorImplPtr B, bool transA,
               bool transB, size_t nrow, size_t ncol, size_t nzip, size_t ldaA,
               size_t ldaB, size_t ldaC, size_t offA = 0L, size_t offB = 0L,

--- a/src/tensor/labeled_tensor.cc
+++ b/src/tensor/labeled_tensor.cc
@@ -784,6 +784,8 @@ void LabeledTensor::contract_batched(const LabeledTensorBatchedContraction &rhs_
             Ltp_batch.contract(inter_tensors[nterms-3], B.T(), sub_indices, inter_indices[nterms-3], B.indices(),
                         add ? B.factor() : -B.factor(),
                         zero_result ? 0.0 : 1.0);
+            // The intermediate tensors in this contraction should be reused for all the batches
+            // to avoid recreating the intermediate of the same size multiple times.
 
             // Copy current batch tensor result to the full result tensor
             const std::vector<double>& Ltc_batch_data = Ltp_batch.data();

--- a/src/tensor/tensor.cc
+++ b/src/tensor/tensor.cc
@@ -384,6 +384,32 @@ Tensor Tensor::power(double alpha, double condition) const
 }
 
 void Tensor::contract(const Tensor &A, const Tensor &B, const Indices &Cinds,
+                      const Indices &Ainds, const Indices &Binds,
+                      std::shared_ptr<TensorImpl> &A2,
+                      std::shared_ptr<TensorImpl> &B2,
+                      std::shared_ptr<TensorImpl> &C2,
+                      double alpha, double beta)
+{
+    if (ambit::settings::debug) {
+        ambit::print("    #: " + std::to_string(beta) + " " + name() + "[" +
+                     indices::to_string(Cinds) + "] = " +
+                     std::to_string(alpha) + " " + A.name() + "[" +
+                     indices::to_string(Ainds) + "] * " + B.name() + "[" +
+                     indices::to_string(Binds) + "]\n");
+    }
+
+    timer::timer_push("#: " + std::to_string(beta) + " " + name() + "[" +
+                      indices::to_string(Cinds) + "] = " +
+                      std::to_string(alpha) + " " + A.name() + "[" +
+                      indices::to_string(Ainds) + "] * " + B.name() + "[" +
+                      indices::to_string(Binds) + "]");
+
+    tensor_->contract(A.tensor_.get(), B.tensor_.get(), Cinds, Ainds, Binds,
+                      A2, B2, C2, alpha, beta);
+
+    timer::timer_pop();
+}
+void Tensor::contract(const Tensor &A, const Tensor &B, const Indices &Cinds,
                       const Indices &Ainds, const Indices &Binds, double alpha,
                       double beta)
 {

--- a/src/tensor/tensorimpl.h
+++ b/src/tensor/tensorimpl.h
@@ -164,6 +164,18 @@ class TensorImpl
             "Operation not supported in this tensor implementation.");
     }
 
+    virtual void contract(ConstTensorImplPtr A, ConstTensorImplPtr B,
+                          const Indices &Cinds, const Indices &Ainds,
+                          const Indices &Binds,
+                          std::shared_ptr<TensorImpl> &A2,
+                          std::shared_ptr<TensorImpl> &B2,
+                          std::shared_ptr<TensorImpl> &C2,
+                          double alpha = 1.0, double beta = 0.0)
+    {
+        throw std::runtime_error(
+            "Operation not supported in this tensor implementation.");
+    }
+
     virtual void gemm(ConstTensorImplPtr A, ConstTensorImplPtr B, bool transA,
                       bool transB, size_t nrow, size_t ncol, size_t nzip,
                       size_t ldaA, size_t ldaB, size_t ldaC, size_t offA = 0L,

--- a/test/test_operators.cc
+++ b/test/test_operators.cc
@@ -1754,6 +1754,45 @@ double test_batched_with_factor()
     return difference(C, c4).second;
 }
 
+double test_batched_with_factor_permute()
+{
+    size_t no = 4;
+
+    std::vector<size_t> dimsA = {no, no, no, no};
+    std::vector<size_t> dimsB = {no, no, no, no};
+    std::vector<size_t> dimsC = {no, no, no, no};
+
+    Tensor A = build_and_fill("A", dimsA, a4);
+    Tensor B = build_and_fill("B", dimsB, b4);
+    Tensor C = build_and_fill("C", dimsC, c4);
+
+    C("ijrs") = batched("r", 0.5 * A("abrs") * B("ijba"));
+
+    for (size_t i = 0; i < no; ++i)
+    {
+        for (size_t j = 0; j < no; ++j)
+        {
+            for (size_t r = 0; r < no; ++r)
+            {
+                for (size_t s = 0; s < no; ++s)
+                {
+                    c4[i][j][r][s] = 0.0;
+                    for (size_t a = 0; a < no; ++a)
+                    {
+                        for (size_t b = 0; b < no; ++b)
+                        {
+                            c4[i][j][r][s] +=
+                                0.5 * a4[a][b][r][s] * b4[i][j][b][a];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return difference(C, c4).second;
+}
+
 int main(int argc, char *argv[])
 {
     srand(time(nullptr));
@@ -1883,6 +1922,9 @@ int main(int argc, char *argv[])
         std::make_tuple(
             kPass, test_batched_with_factor,
             "C2(\"ijrs\") = batched(\"r\", 0.5 * A(\"abrs\") * B(\"ijab\"))"),
+        std::make_tuple(
+            kPass, test_batched_with_factor_permute,
+            "C2(\"ijrs\") = batched(\"r\", 0.5 * A(\"abrs\") * B(\"ijba\"))"),
     };
 
     std::vector<std::tuple<std::string, TestResult, double>> results;


### PR DESCRIPTION
## Description
This PR modifies the batching algorithm to avoid repeated creating tensor contraction intermediates.

For example, the batched contraction
`v["pqrs"] = batched("p", B["gpr"] * B["gqs"]);`
is done by:

Loop over `p`:
(1) Create `v2["qrs"]` and `B2["gr"]`.
(2) Perform contraction `v2["qrs"] = B2["gr"] * B["gqs"]`
In step (2), actually, two additional intermediate tensors: `v3["rqs"]` and `B3["rg"]` are created for permutation purpose.

In the current implementation, intermediate tensors `v2["qrs"]` and `B2["gr"]` in step (1) is reused in every batch to avoid reallocation of memory.
However, because the current implementation directly calls the contraction function originally exist in Ambit, intermediate tensors `v3["rqs"]` and `B3["rg"]` are still created in every batch contraction.

This PR modifies the code to avoid recreating contraction intermediate permutation tensors like `v3["rqs"]` and `B3["rg"]`.

## Solution
Currently, the contraction intermediate permutation tensors are declared in `CoreTensorImpl::contract` core.cc: Line 502:
```c++
    shared_ptr<CoreTensorImpl> C2;
    shared_ptr<CoreTensorImpl> B2;
    shared_ptr<CoreTensorImpl> A2;
```

The function calling stack is:
```c++
LabeledTensor::contract_batched(const LabeledTensorBatchedContraction &rhs, 
                                bool zero_result, bool add) {
    Loop over batches:
        Tensor::contract(const Tensor &A, const Tensor &B, const Indices &Cinds,
                         const Indices &Ainds, const Indices &Binds,
                         double alpha = 1.0, double beta = 0.0) {
            TensorImpl::contract(ConstTensorImplPtr A, ConstTensorImplPtr B,
                                 const Indices &Cinds, const Indices &Ainds,
                                 const Indices &Binds, double alpha = 1.0,
                                 double beta = 0.0) {
                shared_ptr<CoreTensorImpl> C2;
                shared_ptr<CoreTensorImpl> B2;
                shared_ptr<CoreTensorImpl> A2;
            }
        }
}
```
The problem can be solved by move the declaration to the outer most function:
```c++
LabeledTensor::contract_batched(const LabeledTensorBatchedContraction &rhs, 
                                bool zero_result, bool add) {
    Loop over batches:
        shared_ptr<TensorImpl> C2;
        shared_ptr<TensorImpl> B2;
        shared_ptr<TensorImpl> A2;
        Tensor::contract(const Tensor &A, const Tensor &B, const Indices &Cinds,
                         const Indices &Ainds, const Indices &Binds,
                         double alpha = 1.0, double beta = 0.0, 
                         shared_ptr<TensorImpl>& A2, 
                         shared_ptr<TensorImpl>& B2,
                         shared_ptr<TensorImpl>& C2) {
            TensorImpl::contract(ConstTensorImplPtr A, ConstTensorImplPtr B,
                                 const Indices &Cinds, const Indices &Ainds,
                                 const Indices &Binds, double alpha = 1.0,
                                 double beta = 0.0, 
                                 shared_ptr<TensorImpl>& A2, 
                                 shared_ptr<TensorImpl>& B2,
                                 shared_ptr<TensorImpl>& C2) {
            }
        }
}
```
In this solution, we may need to overload `Tensor::contract` and `TensorImpl::contract`.

## Todos
- [x] Overload functions.
- [x] Implement algorithm.
## Status
- [x] Ready to go