### PR TITLE
Fix bug in expert mode without matching contraction block.

### DIFF
--- a/src/blocked_tensor/blocked_tensor.cc
+++ b/src/blocked_tensor/blocked_tensor.cc
@@ -1164,6 +1164,9 @@ void LabeledBlockedTensor::contract(const LabeledBlockedTensorProduct &rhs,
                 }
                 if (not BT().is_block(result_key))
                     continue;
+                else if (zero_result) {
+                    BT_.block(result_key).zero();
+                }
                 for (size_t n = 0; n < nterms; ++n)
                 {
                     const LabeledBlockedTensor &lbt = rhs[n];
@@ -1176,6 +1179,9 @@ void LabeledBlockedTensor::contract(const LabeledBlockedTensorProduct &rhs,
                         continue;
                 }
                 unique_indices_keys.push_back(uik);
+            }
+            if (unique_indices_keys.size() == 0) {
+                return;
             }
             if (full_contraction_size > unique_indices_keys.size()) {
                 full_contraction = false;
@@ -1334,6 +1340,9 @@ void LabeledBlockedTensor::contract_batched(const LabeledBlockedTensorBatchedPro
             }
             if (not BT().is_block(result_key))
                 continue;
+            else if (zero_result) {
+                BT_.block(result_key).zero();
+            }
             bool do_contraction = true;
             for (size_t n = 0; n < nterms; ++n)
             {
@@ -1351,6 +1360,9 @@ void LabeledBlockedTensor::contract_batched(const LabeledBlockedTensorBatchedPro
             if (do_contraction) {
                 unique_indices_keys.push_back(uik);
             }
+        }
+        if (unique_indices_keys.size() == 0) {
+            return;
         }
         if (full_contraction_size > unique_indices_keys.size()) {
             full_contraction = false;


### PR DESCRIPTION
This PR fixed a bug introduced in https://github.com/jturney/ambit/pull/31.

In contraction
```cpp
// add Ambit index labels
BlockedTensor::add_mo_space("c", "mn", core_mos_, AlphaSpin);
BlockedTensor::add_mo_space("a", "uv", actv_mos_, AlphaSpin);
BlockedTensor::add_mo_space("v", "ef", virt_mos_, AlphaSpin);

// define composite spaces
BlockedTensor::add_composite_mo_space("h", "ijkl", {acore_label_, aactv_label_});
BlockedTensor::add_composite_mo_space("p", "abcd", {aactv_label_, avirt_label_});

BlockedTensor G = BlockedTensor::build(CoreTensor, "Gamma1", {"aa"});
BlockedTensor O = BlockedTensor::build(CoreTensor, "O1 PT3 1/3", {"pc", "va"});
BlockedTensor C = BlockedTensor::build(CoreTensor, "C1", {"cp", "av", "pc", "va"});
BlockedTensor T = BlockedTensor::build(CoreTensor, "T2 Amplitudes", {"hhpp"});

O["ia"] = C["bu"] * G["uv"] * T["ivab"];
```
Index `ia` for `O` implies blocks `ca`, `aa`, `cv`, `av`. However, none of them are declared in blocked tensor `O`. The original code builds an intermediate tensor for `C["bu"] * G["uv"]` with no blocks, and contraction with empty blocked tensor causes and exception.

This PR solved the problem by figuring out the contraction actually requires no effort. The code will directly return. If some results blocks need to be set to zero, the code will also zero them accordingly.

## Status
- [x] Ready to go.