### PR TITLE
Fixed bug when all result indices are batched.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_script:
 - export CC=${C_COMPILER}
 - |
   if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-    pyenv global 3.6
+    pyenv global 3.7
   fi
 - cmake -H. -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -Bobjdir
 - cd objdir

--- a/src/blocked_tensor/blocked_tensor.cc
+++ b/src/blocked_tensor/blocked_tensor.cc
@@ -1490,6 +1490,9 @@ void LabeledBlockedTensor::contract_batched(const LabeledBlockedTensorBatchedPro
                 Lt.BT().blocks_,
                 full_contraction);
     BlockedTensor Ltp_batch = BlockedTensor::build(CoreTensor, Lt.BT().name() + " batch", L_batch_blocks);
+    if (L_batch_blocks.empty()) {
+        Ltp_batch.blocks_[{}] = Tensor::build(CoreTensor, Lt.BT().name() + " batch[]", {});
+    }
     LabeledBlockedTensor Lt_batch(Ltp_batch, L_batch_indices);
 
     // Create intermediate batch tensors for tensors to be contracted.
@@ -1550,6 +1553,7 @@ void LabeledBlockedTensor::contract_batched(const LabeledBlockedTensorBatchedPro
                 expert_info_ptr;
         std::vector<std::shared_ptr<std::tuple<std::vector<std::vector<size_t>>, std::map<std::string, size_t>>>>
                 inter_block_info_ptrs(nterms - 1);
+
         while (current_batch[0] < slicing_dims[0]) {
 
             // Extract result batch

--- a/src/blocked_tensor/blocked_tensor.cc
+++ b/src/blocked_tensor/blocked_tensor.cc
@@ -1517,6 +1517,9 @@ void LabeledBlockedTensor::contract_batched(const LabeledBlockedTensorBatchedPro
                         full_contraction);
 
             batch_tensors[i] = BlockedTensor::build(CoreTensor, A.BT().name() + " batch", A_batch_blocks);
+            if (A_batch_blocks.empty()) {
+                batch_tensors[i].blocks_[{}] = Tensor::build(CoreTensor, A.BT().name() + " batch[]", {});
+            }
             LabeledBlockedTensor At(batch_tensors[i], A_batch_indices, A.factor());
             rhs_batch.operator*(At);
         } else {

--- a/test/test_operators.cc
+++ b/test/test_operators.cc
@@ -1668,7 +1668,7 @@ double test_chain_multiply4_batched()
     return difference(D4, d4).second;
 }
 
-double test_batched()
+double test_all_indices_batched()
 {
     size_t ni = 5;
     size_t nj = 6;
@@ -1690,6 +1690,53 @@ double test_batched()
     Tensor D4 = build_and_fill("D4", dimsD, d4);
 
     D4("ijkl") += batched("ijkl", A4("ijmn") * B2("km") * B2("ln"));
+
+    for (size_t i = 0; i < ni; ++i)
+    {
+        for (size_t j = 0; j < nj; ++j)
+        {
+            for (size_t k = 0; k < nk; ++k)
+            {
+                for (size_t l = 0; l < nl; ++l)
+                {
+                    for (size_t m = 0; m < nm; ++m)
+                    {
+                        for (size_t n = 0; n < nn; ++n)
+                        {
+                            d4[i][j][k][l] +=
+                                a4[i][j][m][n] * b2[k][m] * b2[l][n];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return difference(D4, d4).second;
+}
+
+double test_all_indices_batched2()
+{
+    size_t ni = 5;
+    size_t nj = 6;
+    size_t nk = 7;
+    size_t nl = 7;
+    size_t nm = 5;
+    size_t nn = 5;
+    size_t no = 2;
+    size_t np = 2;
+
+    std::vector<size_t> dimsA = {ni, nj, nm, nn};
+    std::vector<size_t> dimsB = {nk, nm};
+    std::vector<size_t> dimsC = {nl, nn};
+    std::vector<size_t> dimsD = {ni, nj, nk, nl};
+
+    Tensor A4 = build_and_fill("A4", dimsA, a4);
+    Tensor B2 = build_and_fill("B2", dimsB, b2);
+    Tensor C2 = build_and_fill("C2", dimsC, c2);
+    Tensor D4 = build_and_fill("D4", dimsD, d4);
+
+    D4("ijkl") += batched("kjil", A4("ijmn") * B2("km") * B2("ln"));
 
     for (size_t i = 0; i < ni; ++i)
     {
@@ -1917,8 +1964,11 @@ int main(int argc, char *argv[])
             kPass, test_chain_multiply4_batched,
             "D4(\"ijkl\") -= batched(\"kl\",A4(\"ijmn\") * B2(\"km\") * C2(\"ln\"))"),
         std::make_tuple(
-            kPass, test_batched,
+            kPass, test_all_indices_batched,
             "D4(\"ijkl\") += batched(\"ijkl\", A4(\"ijmn\") * B2(\"km\") * B2(\"ln\"))"),
+        std::make_tuple(
+            kPass, test_all_indices_batched2,
+            "D4(\"ijkl\") += batched(\"kjil\", A4(\"ijmn\") * B2(\"km\") * B2(\"ln\"))"),
         std::make_tuple(
             kPass, test_batched_with_factor,
             "C2(\"ijrs\") = batched(\"r\", 0.5 * A(\"abrs\") * B(\"ijab\"))"),


### PR DESCRIPTION
This PR fixed a bug when all the indices of result blocked tensor are batched.

### Description ###
In rare case we want to batch over all indices in result tensor, which was not tested.
In the previous implementation, contractions like
```c++
C["ijrs"] = batched("srji", 0.5 * A["abrs"] * B["ijab"]);
```
would generate an exception that the each batch of `C` tensor does not contain any block. However, each batch should actually be a zero-dimension-tensor with only one element, i.e. scalar.
The bug is fixed by creating a zero-dimension `Tensor` object in `BlockedTensor.blocks_`.

### Status ###
- [x] Ready to go
