### PR TITLE
Fix CMake bug on non-apple clang++

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,12 +53,6 @@ matrix:
 install:
 - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
 - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
-#- |
-#  if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-#    brew tap homebrew/science
-#    brew install cmake python gcc
-#    brew install hdf5
-#  fi
 before_script:
 - cd ${TRAVIS_BUILD_DIR}
 - export CXX=${CXX_COMPILER}

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,12 +53,12 @@ matrix:
 install:
 - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
 - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
-- |
-  if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-    brew tap homebrew/science
-    brew install cmake python gcc
-    brew install hdf5
-  fi
+#- |
+#  if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+#    brew tap homebrew/science
+#    brew install cmake python gcc
+#    brew install hdf5
+#  fi
 before_script:
 - cd ${TRAVIS_BUILD_DIR}
 - export CXX=${CXX_COMPILER}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,7 @@
 
 cmake_policy(SET CMP0048 NEW)  # project_VERSION* variables populated from project(... VERSION x.x.x) string
 
-# Fix behavior of CMAKE_CXX_STANDARD when targeting macOS. See https://gitlab.kitware.com/cmake/cmake/issues/15943
-if (POLICY CMP0025)
-  cmake_policy(SET CMP0025 NEW)
-endif ()
+cmake_minimum_required(VERSION 3.1)
 
 project(ambit
         VERSION 0.4.0
@@ -30,8 +27,6 @@ set(ambit_AUTHORS      "Justin M. Turney")
 set(ambit_DESCRIPTION  "C++ library for the implementation of tensor product calculations")
 set(ambit_URL          "https://github.com/jturney/ambit")
 set(ambit_LICENSE      "GNU Lesser General Public License v3 (LGPL-3.0)")
-
-cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,12 @@
 #
 
 cmake_policy(SET CMP0048 NEW)  # project_VERSION* variables populated from project(... VERSION x.x.x) string
+
+# Fix behavior of CMAKE_CXX_STANDARD when targeting macOS. See https://gitlab.kitware.com/cmake/cmake/issues/15943
+if (POLICY CMP0025)
+  cmake_policy(SET CMP0025 NEW)
+endif ()
+
 project(ambit
         VERSION 0.3.0
         LANGUAGES C CXX)

--- a/include/ambit/common_types.h
+++ b/include/ambit/common_types.h
@@ -39,6 +39,7 @@
 #include <vector>
 #include <map>
 #include <string>
+#include <tuple>
 #include <functional>
 #include <memory>
 #include <tuple>

--- a/include/ambit/tensor.h
+++ b/include/ambit/tensor.h
@@ -212,26 +212,12 @@ class Tensor
      * underlying tensor object supports a raw data vector. This is only the
      * case if the underlying tensor is of type CoreTensor.
      *
-     * This routine is intended to facilitate rapid filling of data into a
-     * CoreTensor buffer tensor, following which the user may stripe the buffer
-     * tensor into a DiskTensor or DistributedTensor tensor via slice
-     * operations.
-     *
-     * If a vector is successfully returned, it points to the unrolled data of
-     * the tensor, with the right-most dimensions running fastest and left-most
-     * dimensions running slowest.
-     *
      * Example successful use case:
      *  Tensor A = Tensor::build(CoreTensor, "A3", {4,5,6});
-     *  vector<double>& Av = A[];
-     *  double* Ap = Av.data(); // In case the raw pointer is needed
-     *  In this case, Av[0] = A(0,0,0), Av[1] = A(0,0,1), etc.
-     *
-     *  Tensor B = Tensor::build(DiskTensor, "B3", {4,5,6});
-     *  vector<double>& Bv = B.data(); // throws
+     *  A.at({0,0,0}) = 1.0; // Fill element 
      *
      * Results:
-     *  @return reference to the value, if tensor object supports it
+     *  @return reference to the element, if tensor object supports it
      **/
     double &at(const std::vector<size_t> &indices);
     const double &at(const std::vector<size_t> &indices) const;

--- a/include/ambit/tensor.h
+++ b/include/ambit/tensor.h
@@ -20,9 +20,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along
- * with ambit; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with ambit; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * @END LICENSE
  */
@@ -32,7 +32,6 @@
 
 #include "common_types.h"
 #include "settings.h"
-
 namespace ambit
 {
 
@@ -187,7 +186,7 @@ class Tensor
      * This routine is intended to facilitate rapid filling of data into a
      * CoreTensor buffer tensor, following which the user may stripe the buffer
      * tensor into a DiskTensor or DistributedTensor tensor via slice
-     *operations.
+     * operations.
      *
      * If a vector is successfully returned, it points to the unrolled data of
      * the tensor, with the right-most dimensions running fastest and left-most
@@ -207,6 +206,35 @@ class Tensor
      **/
     vector<double> &data();
     const vector<double> &data() const;
+
+    /**
+     * Returns a reference to an element of the tensor if the
+     * underlying tensor object supports a raw data vector. This is only the
+     * case if the underlying tensor is of type CoreTensor.
+     *
+     * This routine is intended to facilitate rapid filling of data into a
+     * CoreTensor buffer tensor, following which the user may stripe the buffer
+     * tensor into a DiskTensor or DistributedTensor tensor via slice
+     * operations.
+     *
+     * If a vector is successfully returned, it points to the unrolled data of
+     * the tensor, with the right-most dimensions running fastest and left-most
+     * dimensions running slowest.
+     *
+     * Example successful use case:
+     *  Tensor A = Tensor::build(CoreTensor, "A3", {4,5,6});
+     *  vector<double>& Av = A[];
+     *  double* Ap = Av.data(); // In case the raw pointer is needed
+     *  In this case, Av[0] = A(0,0,0), Av[1] = A(0,0,1), etc.
+     *
+     *  Tensor B = Tensor::build(DiskTensor, "B3", {4,5,6});
+     *  vector<double>& Bv = B.data(); // throws
+     *
+     * Results:
+     *  @return reference to the value, if tensor object supports it
+     **/
+    double &at(const std::vector<size_t> &indices);
+    const double &at(const std::vector<size_t> &indices) const;
 
     // => BLAS-Type Tensor Operations <= //
 
@@ -354,8 +382,8 @@ class Tensor
                   const Indices &Ainds, const Indices &Binds,
                   std::shared_ptr<TensorImpl> &A2,
                   std::shared_ptr<TensorImpl> &B2,
-                  std::shared_ptr<TensorImpl> &C2,
-                  double alpha = 1.0, double beta = 0.0);
+                  std::shared_ptr<TensorImpl> &C2, double alpha = 1.0,
+                  double beta = 0.0);
 
     /**
      * Perform the GEMM call equivalent to:
@@ -501,7 +529,6 @@ class Tensor
     map_to_tensor(const map<string, TensorImpl *> &x);
 
   public:
-
     void reshape(const Dimension &dims);
 
     // => Operator Overloading API <= //
@@ -575,8 +602,9 @@ class LabeledTensor
 
     void contract(const LabeledTensorContraction &rhs, bool zero_result,
                   bool add, bool optimize_order = true);
-    void contract_batched(const LabeledTensorBatchedContraction &rhs, bool zero_result,
-                  bool add, bool optimize_order = true);
+    void contract_batched(const LabeledTensorBatchedContraction &rhs,
+                          bool zero_result, bool add,
+                          bool optimize_order = true);
 
   private:
     void set(const LabeledTensor &to);
@@ -629,19 +657,26 @@ class LabeledTensorBatchedContraction
 {
 
   public:
-    LabeledTensorBatchedContraction(const LabeledTensorContraction &contraction, const Indices &batched_indices)
+    LabeledTensorBatchedContraction(const LabeledTensorContraction &contraction,
+                                    const Indices &batched_indices)
         : contraction_(contraction), batched_indices_(batched_indices)
-    {}
+    {
+    }
 
-    const LabeledTensorContraction& get_contraction() const { return contraction_; }
-    const Indices& get_batched_indices() const { return batched_indices_; }
+    const LabeledTensorContraction &get_contraction() const
+    {
+        return contraction_;
+    }
+    const Indices &get_batched_indices() const { return batched_indices_; }
 
   private:
     const LabeledTensorContraction &contraction_;
     Indices batched_indices_;
 };
 
-LabeledTensorBatchedContraction batched(const string &batched_indices, const LabeledTensorContraction &contraction);
+LabeledTensorBatchedContraction
+batched(const string &batched_indices,
+        const LabeledTensorContraction &contraction);
 
 class LabeledTensorAddition
 {
@@ -746,6 +781,6 @@ inline SlicedTensor operator*(double factor, const SlicedTensor &ti)
 {
     return SlicedTensor(ti.T(), ti.range(), factor * ti.factor());
 };
-}
+} // namespace ambit
 
 #endif

--- a/src/tensor/core/core.cc
+++ b/src/tensor/core/core.cc
@@ -335,19 +335,20 @@ void CoreTensorImpl::contract(ConstTensorImplPtr A, ConstTensorImplPtr B,
     }
 
     /**
-    * Fix permutation order considerations
-    *
-    * Rules if a permutation mismatch is detected:
-    * -If both tensors are already on the permute list, it doesn't matter which
-    *is fixed
-    * -Else if one tensor is already on the permute list but not the other, fix
-    *the one that is already on the permute list
-    * -Else fix the smaller tensor
-    *
-    * Note: this scheme is not optimal is permutation mismatches exist in P -
-    *for reasons of simplicity, A and B are
-    * permuted to C's P order, with no present considerations of better pathways
-    **/
+     * Fix permutation order considerations
+     *
+     * Rules if a permutation mismatch is detected:
+     * -If both tensors are already on the permute list, it doesn't matter which
+     *is fixed
+     * -Else if one tensor is already on the permute list but not the other, fix
+     *the one that is already on the permute list
+     * -Else fix the smaller tensor
+     *
+     * Note: this scheme is not optimal is permutation mismatches exist in P -
+     *for reasons of simplicity, A and B are
+     * permuted to C's P order, with no present considerations of better
+     *pathways
+     **/
     if (!indices::equivalent(compound_inds2["iC"], compound_inds2["iA"]))
     {
         if (permC)
@@ -510,7 +511,6 @@ void CoreTensorImpl::contract(ConstTensorImplPtr A, ConstTensorImplPtr B,
     // => Alias or Allocate A, B, C <= //
     // => Permute A, B, and C if Necessary <= //
 
-
     double *Cp = ((CoreTensorImplPtr)C)->data().data();
     double *Ap = ((CoreTensorImplPtr)A)->data().data();
     double *Bp = ((CoreTensorImplPtr)B)->data().data();
@@ -523,7 +523,8 @@ void CoreTensorImpl::contract(ConstTensorImplPtr A, ConstTensorImplPtr B,
         ambit::timer::timer_push("pre-BLAS: internal C allocation");
         if (!C2)
         {
-            Dimension Cdims2 = indices::permuted_dimension(C->dims(), Cinds2, Cinds);
+            Dimension Cdims2 =
+                indices::permuted_dimension(C->dims(), Cinds2, Cinds);
             C2 = std::make_shared<CoreTensorImpl>("C2", Cdims2);
         }
         C2p = C2->data().data();
@@ -540,7 +541,8 @@ void CoreTensorImpl::contract(ConstTensorImplPtr A, ConstTensorImplPtr B,
         ambit::timer::timer_push("pre-BLAS: internal A allocation");
         if (!A2)
         {
-            Dimension Adims2 = indices::permuted_dimension(A->dims(), Ainds2, Ainds);
+            Dimension Adims2 =
+                indices::permuted_dimension(A->dims(), Ainds2, Ainds);
             A2 = std::make_shared<CoreTensorImpl>("A2", Adims2);
         }
         A2p = A2->data().data();
@@ -554,7 +556,8 @@ void CoreTensorImpl::contract(ConstTensorImplPtr A, ConstTensorImplPtr B,
         ambit::timer::timer_push("pre-BLAS: internal B allocation");
         if (!B2)
         {
-            Dimension Bdims2 = indices::permuted_dimension(B->dims(), Binds2, Binds);
+            Dimension Bdims2 =
+                indices::permuted_dimension(B->dims(), Binds2, Binds);
             B2 = std::make_shared<CoreTensorImpl>("B2", Bdims2);
         }
         B2p = B2->data().data();
@@ -704,9 +707,9 @@ void CoreTensorImpl::permute(ConstTensorImplPtr A, const Indices &CindsS,
                              const Indices &AindsS, double alpha, double beta)
 {
     ambit::timer::timer_push("P: " + std::to_string(beta) + " " + A->name() +
-                             "[" + indices::to_string(CindsS) + "] = " +
-                             std::to_string(alpha) + " " + A->name() + "[" +
-                             indices::to_string(AindsS) + "]");
+                             "[" + indices::to_string(CindsS) +
+                             "] = " + std::to_string(alpha) + " " + A->name() +
+                             "[" + indices::to_string(AindsS) + "]");
 
     // => Convert to indices of A <= //
 
@@ -1568,13 +1571,6 @@ void CoreTensorImpl::citerate(
     const function<void(const vector<size_t> &, const double &)> &func) const
 {
     vector<size_t> indices(rank(), 0);
-    vector<size_t> addressing(rank(), 1);
-
-    // form addressing array
-    for (int n = static_cast<int>(rank() - 2); n >= 0; --n)
-    {
-        addressing[n] = addressing[n + 1] * dim(n + 1);
-    }
 
     const size_t nelem = numel();
     const size_t nrank = rank();
@@ -1583,11 +1579,11 @@ void CoreTensorImpl::citerate(
         size_t d = n;
         for (size_t k = 0; k < nrank; ++k)
         {
-            indices[k] = d / addressing[k];
-            d = d % addressing[k];
+            indices[k] = d / addressing()[k];
+            d = d % addressing()[k];
         }
 
         func(indices, data_[n]);
     }
 }
-}
+} // namespace ambit

--- a/src/tensor/core/core.h
+++ b/src/tensor/core/core.h
@@ -20,9 +20,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along
- * with ambit; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with ambit; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * @END LICENSE
  */
@@ -48,6 +48,26 @@ class CoreTensorImpl : public TensorImpl
     vector<double> &data() { return data_; }
     const vector<double> &data() const { return data_; }
 
+    double &at(const std::vector<size_t> &indices)
+    {
+        size_t pos = 0;
+        for (int i = 0, maxi = rank(); i < maxi; i++)
+        {
+            pos += indices[i] * addressing()[i];
+        }
+        return data_[pos];
+    }
+
+    const double &at(const std::vector<size_t> &indices) const
+    {
+        size_t pos = 0;
+        for (int i = 0, maxi = rank(); i < maxi; i++)
+        {
+            pos += indices[i] * addressing()[i];
+        }
+        return data_[pos];
+    }
+
     // => Simple Single Tensor Operations <= //
 
     double norm(int type = 2) const;
@@ -69,11 +89,10 @@ class CoreTensorImpl : public TensorImpl
 
     void contract(ConstTensorImplPtr A, ConstTensorImplPtr B,
                   const Indices &Cinds, const Indices &Ainds,
-                  const Indices &Binds,
-                  std::shared_ptr<TensorImpl> &A2,
+                  const Indices &Binds, std::shared_ptr<TensorImpl> &A2,
                   std::shared_ptr<TensorImpl> &B2,
-                  std::shared_ptr<TensorImpl> &C2,
-                  double alpha = 1.0, double beta = 0.0);
+                  std::shared_ptr<TensorImpl> &C2, double alpha = 1.0,
+                  double beta = 0.0);
 
     void gemm(ConstTensorImplPtr A, ConstTensorImplPtr B, bool transA,
               bool transB, size_t nrow, size_t ncol, size_t nzip, size_t ldaA,
@@ -104,6 +123,6 @@ class CoreTensorImpl : public TensorImpl
 
 typedef CoreTensorImpl *CoreTensorImplPtr;
 typedef const CoreTensorImpl *ConstCoreTensorImplPtr;
-}
+} // namespace ambit
 
 #endif

--- a/src/tensor/tensor.cc
+++ b/src/tensor/tensor.cc
@@ -20,23 +20,23 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along
- * with ambit; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with ambit; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * @END LICENSE
  */
 
+#include <algorithm>
 #include <cstdlib>
 #include <list>
-#include <algorithm>
 
-#include <ambit/tensor.h>
-#include <ambit/print.h>
-#include "tensorimpl.h"
 #include "core/core.h"
 #include "disk/disk.h"
 #include "indices.h"
+#include "tensorimpl.h"
+#include <ambit/print.h>
+#include <ambit/tensor.h>
 
 #include "globals.h"
 
@@ -74,16 +74,17 @@ const bool distributed_capable = false;
 #endif
 
 bool timers = false;
-}
+} // namespace settings
 
 namespace
 {
 
 void common_initialize(int /*argc*/, char *const * /*argv*/)
 {
-    if (settings::ninitialized != 0) {
+    if (settings::ninitialized != 0)
+    {
         throw std::runtime_error(
-                "ambit::initialize: Ambit has already been initialized.");
+            "ambit::initialize: Ambit has already been initialized.");
     }
 
     settings::ninitialized++;
@@ -102,7 +103,7 @@ void common_initialize(int /*argc*/, char *const * /*argv*/)
         Tensor::set_scratch_path(".");
     }
 }
-}
+} // namespace
 
 int initialize(int argc, char **argv)
 {
@@ -117,9 +118,10 @@ int initialize(int argc, char **argv)
 
 void finalize()
 {
-    if (settings::ninitialized == 0) {
+    if (settings::ninitialized == 0)
+    {
         throw std::runtime_error(
-                "ambit::finalize: Ambit has already been finalized.");
+            "ambit::finalize: Ambit has already been finalized.");
     }
 
     settings::ninitialized--;
@@ -145,9 +147,10 @@ Tensor::Tensor(shared_ptr<TensorImpl> tensor) : tensor_(std::move(tensor)) {}
 
 Tensor Tensor::build(TensorType type, const string &name, const Dimension &dims)
 {
-    if (settings::ninitialized == 0) {
+    if (settings::ninitialized == 0)
+    {
         throw std::runtime_error(
-                "ambit::Tensor::build: Ambit has not been initialized.");
+            "ambit::Tensor::build: Ambit has not been initialized.");
     }
 
     ambit::timer::timer_push("Tensor::build");
@@ -253,6 +256,16 @@ std::vector<double> &Tensor::data() { return tensor_->data(); }
 
 const std::vector<double> &Tensor::data() const { return tensor_->data(); }
 
+double &Tensor::at(const std::vector<size_t> &indices)
+{
+    return tensor_->at(indices);
+}
+
+const double &Tensor::at(const std::vector<size_t> &indices) const
+{
+    return tensor_->at(indices);
+}
+
 Tensor Tensor::cat(std::vector<Tensor> const, int dim)
 {
     ThrowNotImplementedException;
@@ -326,8 +339,8 @@ map<string, Tensor> Tensor::map_to_tensor(const map<string, TensorImplPtr> &x)
 
     for (auto iter : x)
     {
-        result.insert(make_pair(iter.first,
-                                Tensor(shared_ptr<TensorImpl>(iter.second))));
+        result.insert(
+            make_pair(iter.first, Tensor(shared_ptr<TensorImpl>(iter.second))));
     }
     return result;
 }
@@ -387,25 +400,26 @@ void Tensor::contract(const Tensor &A, const Tensor &B, const Indices &Cinds,
                       const Indices &Ainds, const Indices &Binds,
                       std::shared_ptr<TensorImpl> &A2,
                       std::shared_ptr<TensorImpl> &B2,
-                      std::shared_ptr<TensorImpl> &C2,
-                      double alpha, double beta)
+                      std::shared_ptr<TensorImpl> &C2, double alpha,
+                      double beta)
 {
-    if (ambit::settings::debug) {
+    if (ambit::settings::debug)
+    {
         ambit::print("    #: " + std::to_string(beta) + " " + name() + "[" +
-                     indices::to_string(Cinds) + "] = " +
-                     std::to_string(alpha) + " " + A.name() + "[" +
+                     indices::to_string(Cinds) +
+                     "] = " + std::to_string(alpha) + " " + A.name() + "[" +
                      indices::to_string(Ainds) + "] * " + B.name() + "[" +
                      indices::to_string(Binds) + "]\n");
     }
 
     timer::timer_push("#: " + std::to_string(beta) + " " + name() + "[" +
-                      indices::to_string(Cinds) + "] = " +
-                      std::to_string(alpha) + " " + A.name() + "[" +
+                      indices::to_string(Cinds) +
+                      "] = " + std::to_string(alpha) + " " + A.name() + "[" +
                       indices::to_string(Ainds) + "] * " + B.name() + "[" +
                       indices::to_string(Binds) + "]");
 
-    tensor_->contract(A.tensor_.get(), B.tensor_.get(), Cinds, Ainds, Binds,
-                      A2, B2, C2, alpha, beta);
+    tensor_->contract(A.tensor_.get(), B.tensor_.get(), Cinds, Ainds, Binds, A2,
+                      B2, C2, alpha, beta);
 
     timer::timer_pop();
 }
@@ -413,17 +427,18 @@ void Tensor::contract(const Tensor &A, const Tensor &B, const Indices &Cinds,
                       const Indices &Ainds, const Indices &Binds, double alpha,
                       double beta)
 {
-    if (ambit::settings::debug) {
+    if (ambit::settings::debug)
+    {
         ambit::print("    #: " + std::to_string(beta) + " " + name() + "[" +
-                     indices::to_string(Cinds) + "] = " +
-                     std::to_string(alpha) + " " + A.name() + "[" +
+                     indices::to_string(Cinds) +
+                     "] = " + std::to_string(alpha) + " " + A.name() + "[" +
                      indices::to_string(Ainds) + "] * " + B.name() + "[" +
                      indices::to_string(Binds) + "]\n");
     }
 
     timer::timer_push("#: " + std::to_string(beta) + " " + name() + "[" +
-                      indices::to_string(Cinds) + "] = " +
-                      std::to_string(alpha) + " " + A.name() + "[" +
+                      indices::to_string(Cinds) +
+                      "] = " + std::to_string(alpha) + " " + A.name() + "[" +
                       indices::to_string(Ainds) + "] * " + B.name() + "[" +
                       indices::to_string(Binds) + "]");
 
@@ -435,7 +450,8 @@ void Tensor::contract(const Tensor &A, const Tensor &B, const Indices &Cinds,
 void Tensor::permute(const Tensor &A, const Indices &Cinds,
                      const Indices &Ainds, double alpha, double beta)
 {
-    if (ambit::settings::debug) {
+    if (ambit::settings::debug)
+    {
         ambit::print("    P: " + name() + "[" + indices::to_string(Cinds) +
                      "] = " + A.name() + "[" + indices::to_string(Ainds) +
                      "]\n");
@@ -479,4 +495,4 @@ bool Tensor::operator!=(const Tensor &other) const
 {
     return tensor_ != other.tensor_;
 }
-}
+} // namespace ambit

--- a/src/tensor/tensorimpl.cc
+++ b/src/tensor/tensorimpl.cc
@@ -20,18 +20,18 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along
- * with ambit; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with ambit; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * @END LICENSE
  */
 
-#include <numeric>
 #include "tensorimpl.h"
 #include "core/core.h"
 #include "disk/disk.h"
 #include "slice.h"
+#include <numeric>
 
 #if defined(HAVE_CYCLOPS)
 #include "cyclops/cyclops.h"
@@ -46,6 +46,12 @@ TensorImpl::TensorImpl(TensorType type, const string &name,
 {
     numel_ = std::accumulate(dims_.begin(), dims_.end(), static_cast<size_t>(1),
                              std::multiplies<size_t>());
+
+    addressing_ = Dimension(dims_.size(), 1);
+    for (int n = static_cast<int>(dims_.size()) - 2; n >= 0; --n)
+    {
+        addressing_[n] = addressing_[n + 1] * dims_[n + 1];
+    }
 }
 
 void TensorImpl::slice(ConstTensorImplPtr A, const IndexRange &Cinds,
@@ -54,8 +60,7 @@ void TensorImpl::slice(ConstTensorImplPtr A, const IndexRange &Cinds,
     ambit::slice(this, A, Cinds, Ainds, alpha, beta);
 }
 
-void TensorImpl::zero()
-{ scale(0.0); }
+void TensorImpl::zero() { scale(0.0); }
 
 void TensorImpl::copy(ConstTensorImplPtr other)
 {
@@ -85,10 +90,10 @@ TensorImplPtr TensorImpl::clone(TensorType t) const
         tensor = new DiskTensorImpl(name(), dims());
     }
 #if defined(HAVE_ELEMENTAL)
-        else if (t == DistributedTensor)
-        {
-            tensor = new cyclops::CyclopsTensorImpl(name(), dims());
-        }
+    else if (t == DistributedTensor)
+    {
+        tensor = new cyclops::CyclopsTensorImpl(name(), dims());
+    }
 #endif
     else
     {
@@ -185,8 +190,8 @@ void TensorImpl::print(FILE *fh, bool level, const string & /*format*/,
                          j += static_cast<size_t>(maxcols))
                     {
                         size_t ncols = (j + static_cast<size_t>(maxcols) >= cols
-                                        ? cols - j
-                                        : static_cast<size_t>(maxcols));
+                                            ? cols - j
+                                            : static_cast<size_t>(maxcols));
 
                         // Column Header
                         fprintf(fh, "    %5s", "");
@@ -295,4 +300,4 @@ bool TensorImpl::dimensionCheck(ConstTensorImplPtr A, ConstTensorImplPtr B,
         return diff;
     }
 }
-}
+} // namespace ambit

--- a/test/test_core.cc
+++ b/test/test_core.cc
@@ -20,9 +20,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along
- * with ambit; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with ambit; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * @END LICENSE
  */
@@ -2219,10 +2219,7 @@ double try_C_equal_A_B(std::string c_ind, std::string a_ind, std::string b_ind,
                        std::vector<int> c_dim, std::vector<int> a_dim,
                        std::vector<int> b_dim)
 {
-    std::vector<size_t> dims;
-    dims.push_back(3);
-    dims.push_back(4);
-    dims.push_back(5);
+    std::vector<size_t> dims = {3, 4, 5};
 
     size_t ni = 3;
     size_t nj = 4;
@@ -2440,6 +2437,39 @@ double try_contract_size_fail4()
 
     return 0.0;
 }
+double try_get()
+{
+    double error = 0.0;
+    Dimension Cdims = {1, 3, 4};
+    Tensor C = Tensor::build(CoreTensor, "C", Cdims);
+    double index = 0.0;
+    for (size_t i = 0; i < Cdims[0]; i++)
+    {
+        for (size_t j = 0; j < Cdims[1]; j++)
+        {
+            for (size_t k = 0; k < Cdims[2]; k++)
+            {
+                C.at({i, j, k}) = index;
+                index += 1.0;
+            }
+        }
+    }
+    index = 0.0;
+    for (size_t i = 0; i < Cdims[0]; i++)
+    {
+        for (size_t j = 0; j < Cdims[1]; j++)
+        {
+            for (size_t k = 0; k < Cdims[2]; k++)
+            {
+                const double val = C.at({i, j, k});
+                error += std::fabs(val - index);
+                index += 1.0;
+            }
+        }
+    }
+
+    return error;
+}
 
 int main(int argc, char *argv[])
 {
@@ -2463,6 +2493,7 @@ int main(int argc, char *argv[])
     success &= test_function(try_zero, "Zero", kExact);
     success &= test_function(try_copy, "Copy", kExact);
     success &= test_function(try_scale, "Scale", kExact);
+    success &= test_function(try_get, "Get/Set", kExact);
     printf("%s\n", std::string(82, '-').c_str());
     printf("Tests: %s\n\n", success ? "All passed" : "Some failed");
 


### PR DESCRIPTION
Fix an problem with CMake (https://gitlab.kitware.com/cmake/cmake/issues/15943) that prevents recognizing the activation of the C++11 standard.