### PR TITLE
Fix warnings

### DIFF
--- a/include/ambit/blocked_tensor.h
+++ b/include/ambit/blocked_tensor.h
@@ -469,7 +469,7 @@ inline LabeledBlockedTensor operator*(double factor,
                                       const LabeledBlockedTensor &ti)
 {
     return LabeledBlockedTensor(ti.BT(), ti.indices(), factor * ti.factor());
-};
+}
 
 class LabeledBlockedTensorProduct
 {

--- a/include/ambit/tensor.h
+++ b/include/ambit/tensor.h
@@ -603,7 +603,7 @@ class LabeledTensor
 inline LabeledTensor operator*(double factor, const LabeledTensor &ti)
 {
     return LabeledTensor(ti.T(), ti.indices(), factor * ti.factor());
-};
+}
 
 class LabeledTensorContraction
 {
@@ -766,7 +766,7 @@ class SlicedTensor
 inline SlicedTensor operator*(double factor, const SlicedTensor &ti)
 {
     return SlicedTensor(ti.T(), ti.range(), factor * ti.factor());
-};
+}
 } // namespace ambit
 
 #endif


### PR DESCRIPTION
Fix warnings due to extra ";" at the end of function definitions.