### PR TITLE
Sync `SlicedTensor`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - NumPyBind
   pull_request:
 jobs:
   build-test-repo:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(ambit_DESCRIPTION  "C++ library for the implementation of tensor product cal
 set(ambit_URL          "https://github.com/jturney/ambit")
 set(ambit_LICENSE      "GNU Lesser General Public License v3 (LGPL-3.0)")
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(TargetOpenMP_FIND_COMPONENTS "CXX")
 

--- a/include/ambit/tensor.h
+++ b/include/ambit/tensor.h
@@ -812,6 +812,7 @@ class SlicedTensor
     double factor() const { return factor_; }
     const IndexRange &range() const { return range_; }
     const Tensor &T() const { return T_; }
+    size_t rank() const { return T_.rank(); }
 
     void operator=(const SlicedTensor &rhs);
     void operator+=(const SlicedTensor &rhs);

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -29,6 +29,7 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
 #include <ambit/tensor.h>
@@ -92,6 +93,15 @@ PYBIND11_MODULE(pyambit, m)
         .def_property_readonly("factor", &LabeledTensor::factor, "docstring")
         .def_property_readonly("indices", idx(&LabeledTensor::indices), py::return_value_policy::copy)
         .def("dim_by_index", &LabeledTensor::dim_by_index);
+
+    py::class_<SlicedTensor>(m, "SlicedTensor")
+        .def(py::init<Tensor, const IndexRange &, double>(), "T"_a, "range"_a, "factor"_a=1)
+        .def(py::self += py::self)
+        .def(py::self -= py::self)
+        .def_property_readonly("tensor", &SlicedTensor::T)
+        .def_property_readonly("range", &SlicedTensor::range)
+        .def_property_readonly("rank", &SlicedTensor::rank)
+        .def_property_readonly("factor", &SlicedTensor::factor);
 
     typedef void (Tensor::*contract1)(const Tensor &A, const Tensor &B, const Indices &Cinds,
             const Indices &Ainds, const Indices &Binds, double alpha, double beta);


### PR DESCRIPTION
This PR destroys the Py-side `SlicedTensor` class, instead pybinding the C-side `SlicedTensor` class.

Other points of interest:
- Remove a temporary branch that had GHA test authority
- Update C++ standard from 11 to 17