### PR TITLE
Sync LabeledDistributive

### DIFF
--- a/include/ambit/tensor.h
+++ b/include/ambit/tensor.h
@@ -800,8 +800,8 @@ class LabeledTensorDistribution
     operator double() const;
 
   private:
-    const LabeledTensor &A_;
-    const LabeledTensorAddition &B_;
+    const LabeledTensor A_;
+    const LabeledTensorAddition B_;
 };
 
 class SlicedTensor

--- a/lib/ambit/blocked_tensor.py
+++ b/lib/ambit/blocked_tensor.py
@@ -186,9 +186,8 @@ class LabeledBlockedTensorDistributive:
             term_key = ""
             for index in self.A.indices:
                 term_key += uik[index_map[index]]
-
             A = tensor_wrapper.LabeledTensor(self.A.btensor.block(term_key).tensor, self.A.indices, self.A.factor)
-            dist = tensor_wrapper.LabeledTensorDistributive(A, prod)
+            dist = pyambit.LabeledTensorDistributive(A.to_C(), prod.to_C())
             result += float(dist)
 
         return result

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -92,7 +92,18 @@ PYBIND11_MODULE(pyambit, m)
         .def(py::init<Tensor, const std::vector<std::string> &, double>())
         .def_property_readonly("factor", &LabeledTensor::factor, "docstring")
         .def_property_readonly("indices", idx(&LabeledTensor::indices), py::return_value_policy::copy)
+        .def_property_readonly("tensor", &LabeledTensor::T)
         .def("dim_by_index", &LabeledTensor::dim_by_index);
+
+    py::class_<LabeledTensorAddition>(m, "LabeledTensorAddition")
+        .def(py::init<const LabeledTensor&, const LabeledTensor&>())
+        .def("__iter__", [](const LabeledTensorAddition& t) { return py::make_iterator(t.begin(), t.end()); }, py::keep_alive<0, 1>());
+
+    py::class_<LabeledTensorDistribution>(m, "LabeledTensorDistributive")
+        .def(py::init<const LabeledTensor&, const LabeledTensorAddition&>())
+        .def("__float__", [](const LabeledTensorDistribution& t) { return static_cast<double>(t); })
+        .def_property_readonly("A", &LabeledTensorDistribution::A)
+        .def_property_readonly("B", &LabeledTensorDistribution::B);
 
     py::class_<SlicedTensor>(m, "SlicedTensor")
         .def(py::init<Tensor, const IndexRange &, double>(), "T"_a, "range"_a, "factor"_a=1)

--- a/src/tensor/labeled_tensor.cc
+++ b/src/tensor/labeled_tensor.cc
@@ -353,11 +353,11 @@ LabeledTensorAddition &LabeledTensorAddition::operator-()
 
 LabeledTensorContraction::operator double() const
 {
-    Tensor R = Tensor::build(tensors_[0].T().type(), "R", {});
+    auto R = Tensor::build(tensors_[0].T().type(), "R", {});
     LabeledTensor lR(R, {}, 1.0);
     lR.contract(*this, true, true);
 
-    Tensor C = Tensor::build(CoreTensor, "C", {});
+    auto C = Tensor::build(CoreTensor, "C", {});
     C.slice(R, {}, {});
 
     return C.data()[0];
@@ -464,7 +464,7 @@ pair<double, double> LabeledTensorContraction::compute_contraction_cost(
 
 LabeledTensorDistribution::operator double() const
 {
-    Tensor R = Tensor::build(A_.T().type(), "R", {});
+    auto R = Tensor::build(A_.T().type(), "R", {});
 
     for (size_t ind = 0L; ind < B_.size(); ind++)
     {
@@ -473,7 +473,7 @@ LabeledTensorDistribution::operator double() const
                    A_.factor() * B_[ind].factor(), 1.0);
     }
 
-    Tensor C = Tensor::build(CoreTensor, "C", {});
+    auto C = Tensor::build(CoreTensor, "C", {});
     C.slice(R, {}, {});
 
     return C.data()[0];


### PR DESCRIPTION
We return to the C-side version of the `LabeledTensorDistributive` class. An important side effect of this PR is that the class now stores copies of its arguments, rather than references to them. This is in keeping with the behavior of the other Labeled C-side classes. Trying to store references was leading to problems when the references were no longer valid. I haven't done performance evaluation, and it may be worth changing to a different solution later, but this is good enough for now.