### PR TITLE
Sync `LabeledTensorAddition`

### DIFF
--- a/include/ambit/tensor.h
+++ b/include/ambit/tensor.h
@@ -733,6 +733,7 @@ batched(const string &batched_indices,
 class LabeledTensorAddition
 {
   public:
+    LabeledTensorAddition() {}
     LabeledTensorAddition(const LabeledTensor &A, const LabeledTensor &B)
     {
         tensors_.push_back(A);
@@ -752,10 +753,17 @@ class LabeledTensorAddition
     vector<LabeledTensor>::iterator end() { return tensors_.end(); }
     vector<LabeledTensor>::const_iterator end() const { return tensors_.end(); }
 
-    LabeledTensorAddition &operator+(const LabeledTensor &other)
+    LabeledTensorAddition& operator+=(const LabeledTensor &other)
     {
         tensors_.push_back(other);
         return *this;
+    }
+
+    LabeledTensorAddition operator+(const LabeledTensor &other) const
+    {
+        LabeledTensorAddition copy(*this);
+        copy.tensors_.push_back(other);
+        return copy;
     }
 
     LabeledTensorAddition &operator-(const LabeledTensor &other)
@@ -764,12 +772,12 @@ class LabeledTensorAddition
         return *this;
     }
 
-    LabeledTensorDistribution operator*(const LabeledTensor &other);
+    LabeledTensorDistribution operator*(const LabeledTensor &other) const;
 
     LabeledTensorAddition &operator*(double scalar);
 
     // negation
-    LabeledTensorAddition &operator-();
+    LabeledTensorAddition operator-() const;
 
   private:
     // This handles cases like T("ijab")

--- a/lib/ambit/blocked_tensor.py
+++ b/lib/ambit/blocked_tensor.py
@@ -175,19 +175,19 @@ class LabeledBlockedTensorDistributive:
         # Setup and perform contractions
         result = 0.0
         for uik in unique_indices_key:
-            prod = tensor_wrapper.LabeledTensorAddition(None, None)
+            prod = pyambit.LabeledTensorAddition()
             for lbt in self.B.tensors:
                 term_key = ""
                 for index in lbt.indices:
                     term_key += uik[index_map[index]]
                 term = tensor_wrapper.LabeledTensor(lbt.btensor.block(term_key).tensor, lbt.indices, lbt.factor)
-                prod.tensors.append(term)
+                prod += term.to_C()
 
             term_key = ""
             for index in self.A.indices:
                 term_key += uik[index_map[index]]
             A = tensor_wrapper.LabeledTensor(self.A.btensor.block(term_key).tensor, self.A.indices, self.A.factor)
-            dist = pyambit.LabeledTensorDistributive(A.to_C(), prod.to_C())
+            dist = pyambit.LabeledTensorDistributive(A.to_C(), prod)
             result += float(dist)
 
         return result

--- a/lib/test_operators.py
+++ b/lib/test_operators.py
@@ -503,7 +503,7 @@ class TestOperatorOverloading(unittest.TestCase):
         [C, nC] = self.build_and_fill("C", [ni, nj])
         [D, nD] = self.build_and_fill("D", [ni, nj])
 
-        D["ij"] = A["ij"] +  B["ij"] + C["ij"]
+        D["ij"] = A["ij"] +  B["ij"] + C["ij"].to_C() # Dirty hack until LabeledTensor becomes C
 
         for i in range(ni):
             for j in range(nj):
@@ -536,7 +536,7 @@ class TestOperatorOverloading(unittest.TestCase):
         [C, nC] = self.build_and_fill("C", [ni, nj])
         [D, nD] = self.build_and_fill("D", [ni, nj])
 
-        D["ij"] = A["ij"] -  B["ij"] + 2.0*C["ij"]
+        D["ij"] = A["ij"] -  B["ij"] + (2.0*C["ij"]).to_C() # Dirty hack until LabeledTensor becomes C
 
         for i in range(ni):
             for j in range(nj):
@@ -570,7 +570,7 @@ class TestOperatorOverloading(unittest.TestCase):
         [C, nC] = self.build_and_fill("C", [ni, nj])
         [D, nD] = self.build_and_fill("D", [ni, nj])
 
-        D["ij"] = (2.0*B["ij"] - C["ij"]) * A["ij"]
+        D["ij"] = (2.0*B["ij"] - C["ij"]) * A["ij"].to_C() # Dirty hack until LabeledTensor becomes C
 
         for i in range(ni):
             for j in range(nj):

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -97,7 +97,13 @@ PYBIND11_MODULE(pyambit, m)
 
     py::class_<LabeledTensorAddition>(m, "LabeledTensorAddition")
         .def(py::init<const LabeledTensor&, const LabeledTensor&>())
-        .def("__iter__", [](const LabeledTensorAddition& t) { return py::make_iterator(t.begin(), t.end()); }, py::keep_alive<0, 1>());
+        .def(py::init<>())
+        .def("__iter__", [](const LabeledTensorAddition& t) { return py::make_iterator(t.begin(), t.end()); }, py::keep_alive<0, 1>())
+        .def(-py::self)
+        .def("__add__", [](const LabeledTensorAddition& s1, const LabeledTensor& s2) { return s1 + s2; })
+        .def("__iadd__", [](LabeledTensorAddition& s1, const LabeledTensor& s2) { return s1 += s2; })
+        .def("__mul__", [](const LabeledTensorAddition& s1, const LabeledTensor& s2) { return s1 * s2; })
+        .def(float() * py::self);
 
     py::class_<LabeledTensorDistribution>(m, "LabeledTensorDistributive")
         .def(py::init<const LabeledTensor&, const LabeledTensorAddition&>())

--- a/src/tensor/labeled_tensor.cc
+++ b/src/tensor/labeled_tensor.cc
@@ -325,7 +325,7 @@ void LabeledTensor::operator-=(const LabeledTensorDistribution &rhs)
 }
 
 LabeledTensorDistribution LabeledTensorAddition::
-operator*(const LabeledTensor &other)
+operator*(const LabeledTensor &other) const
 {
     return LabeledTensorDistribution(other, *this);
 }
@@ -341,14 +341,15 @@ LabeledTensorAddition &LabeledTensorAddition::operator*(double scalar)
     return *this;
 }
 
-LabeledTensorAddition &LabeledTensorAddition::operator-()
+LabeledTensorAddition LabeledTensorAddition::operator-() const
 {
-    for (LabeledTensor &T : tensors_)
+    LabeledTensorAddition copy(*this);
+    for (LabeledTensor &T : copy)
     {
         T *= -1.0;
     }
 
-    return *this;
+    return copy;
 }
 
 LabeledTensorContraction::operator double() const


### PR DESCRIPTION
This PR removes the Py-side `LabeledTensorAddition` class. A list of the changes on the C++ layer:

* Added an empty constructor to `LabeledTensorAddition`
* The current overload of + on `LabeledTensorAddition` changed the operator in-place. That has changed to +=, and a const + overload has been created.
* Similarly, the overloads of * and - have been changed to be const