### PR TITLE
Sync LabeledTensorProduct

### DIFF
--- a/include/ambit/tensor.h
+++ b/include/ambit/tensor.h
@@ -658,8 +658,9 @@ class LabeledTensor
                           bool zero_result, bool add,
                           bool optimize_order = true);
 
+    void set(const LabeledTensor &to); // This function is dangerous!
+
   private:
-    void set(const LabeledTensor &to);
 
     Tensor T_;
     Indices indices_;
@@ -687,13 +688,17 @@ class LabeledTensorContraction
 
     const LabeledTensor &operator[](size_t i) const { return tensors_[i]; }
 
-    LabeledTensorContraction &operator*(const LabeledTensor &other)
+    LabeledTensorContraction &operator*=(const LabeledTensor &other)
     {
         tensors_.push_back(other);
         return *this;
     }
 
-    void operator*=(const LabeledTensor &other) { tensors_.push_back(other); }
+    LabeledTensorContraction operator*(const LabeledTensor &other) const {
+        LabeledTensorContraction copy(*this);
+        copy *= other;
+        return copy;
+    }
 
     // conversion operator
     operator double() const;

--- a/lib/ambit/blocked_tensor.py
+++ b/lib/ambit/blocked_tensor.py
@@ -105,13 +105,13 @@ class LabeledBlockedTensorProduct:
         # Setup and perform contractions
         result = 0.0
         for uik in unique_indices_key:
-            prod = tensor_wrapper.LabeledTensorProduct(None, None)
+            prod = pyambit.LabeledTensorContraction()
             for lbt in self.btensors:
                 term_key = ""
                 for index in lbt.indices:
                     term_key += uik[index_map[index]]
                 term = tensor_wrapper.LabeledTensor(lbt.btensor.block(term_key).tensor, lbt.indices, lbt.factor)
-                prod.tensors.append(term)
+                prod *= term.to_C()
 
             result += float(prod)
 
@@ -263,14 +263,14 @@ class LabeledBlockedTensor:
                 result = tensor_wrapper.LabeledTensor(self.btensor.block(result_key).tensor, self.indices, self.factor)
 
                 # print("tensor: %s" % self.btensor.block(result_key).tensor)
-                prod = tensor_wrapper.LabeledTensorProduct(None, None)
+                prod = pyambit.LabeledTensorContraction()
                 for lbt in rhs.btensors:
                     term_key = ""
                     for index in lbt.indices:
                         term_key += uik[index_map[index]]
                     # print("term_key: " + str(term_key))
                     term = tensor_wrapper.LabeledTensor(lbt.btensor.block(term_key).tensor, lbt.indices, lbt.factor)
-                    prod.tensors.append(term)
+                    prod *= term.to_C()
 
                 if add == True:
                     result += prod

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -93,7 +93,8 @@ PYBIND11_MODULE(pyambit, m)
         .def_property_readonly("factor", &LabeledTensor::factor, "docstring")
         .def_property_readonly("indices", idx(&LabeledTensor::indices), py::return_value_policy::copy)
         .def_property_readonly("tensor", &LabeledTensor::T)
-        .def("dim_by_index", &LabeledTensor::dim_by_index);
+        .def("dim_by_index", &LabeledTensor::dim_by_index)
+        .def("set", &LabeledTensor::set);
 
     py::class_<LabeledTensorAddition>(m, "LabeledTensorAddition")
         .def(py::init<const LabeledTensor&, const LabeledTensor&>())
@@ -104,6 +105,16 @@ PYBIND11_MODULE(pyambit, m)
         .def("__iadd__", [](LabeledTensorAddition& s1, const LabeledTensor& s2) { return s1 += s2; })
         .def("__mul__", [](const LabeledTensorAddition& s1, const LabeledTensor& s2) { return s1 * s2; })
         .def(float() * py::self);
+
+    py::class_<LabeledTensorContraction>(m, "LabeledTensorContraction")
+        .def(py::init<const LabeledTensor&, const LabeledTensor&>())
+        .def(py::init<>())
+        .def("__float__", [](const LabeledTensorContraction& t) { return static_cast<double>(t); })
+        .def("__len__", &LabeledTensorContraction::size)
+        .def("__imul__", [](LabeledTensorContraction& s1, const LabeledTensor& s2) { return s1 *= s2; })
+        .def(float() * py::self)
+        .def("__getitem__", [](const LabeledTensorContraction& t, size_t i) { return t[i]; })
+        .def("compute_contraction_cost", &LabeledTensorContraction::compute_contraction_cost);
 
     py::class_<LabeledTensorDistribution>(m, "LabeledTensorDistributive")
         .def(py::init<const LabeledTensor&, const LabeledTensorAddition&>())

--- a/src/tensor/labeled_tensor.cc
+++ b/src/tensor/labeled_tensor.cc
@@ -587,11 +587,11 @@ void LabeledTensor::contract_batched(const LabeledTensorBatchedContraction &rhs_
             }
         }
         if (permuted_indices.size() == 0) {
-            rhsp.operator*(A);
+            rhsp *= A;
         } else {
             permuted_indices.insert(permuted_indices.end(),gemm_indices.begin(),gemm_indices.end());
             if (permuted_indices == A_indices) {
-                rhsp.operator*(A);
+                rhsp *= A;
             } else {
                 Dimension dims;
                 for (const string& s : permuted_indices) {
@@ -600,7 +600,7 @@ void LabeledTensor::contract_batched(const LabeledTensorBatchedContraction &rhs_
                 Tensor Atp = Tensor::build(A.T().type(), A.T().name() + " permute", dims);
                 Atp.permute(A.T(), permuted_indices, A.indices());
                 LabeledTensor At(Atp, permuted_indices, A.factor());
-                rhsp.operator*(At);
+                rhsp *= At;
             }
         }
     }
@@ -636,10 +636,10 @@ void LabeledTensor::contract_batched(const LabeledTensorBatchedContraction &rhs_
 
             Tensor Atp = Tensor::build(A.T().type(), A.T().name() + " batch", dims);
             LabeledTensor At(Atp, indices, A.factor());
-            rhs_batch.operator*(At);
+            rhs_batch *= At;
             batch_tensors.push_back(Atp);
         } else {
-            rhs_batch.operator*(A);
+            rhs_batch *= A;
             batch_tensors.push_back(A.T());
         }
     }


### PR DESCRIPTION
The next re-sync of C and Py classes. The C-side `LabeledTensorContraction` has its `*` and `*=` overloads changed to better match expected behavior, especially with regards to whether the left operand is `const` or not.