### PR TITLE
Remove some lightweight classes

### DIFF
--- a/include/ambit/blocked_tensor.h
+++ b/include/ambit/blocked_tensor.h
@@ -91,6 +91,8 @@ class MOSpace
     MOSpace(const std::string &name, const std::string &mo_indices,
             std::vector<std::pair<size_t, SpinType>> mos_spin);
 
+    void common_init() const;
+
     // => Accessors <= //
 
     /// @return The label of this molecular orbital space

--- a/lib/ambit/__init__.py
+++ b/lib/ambit/__init__.py
@@ -31,6 +31,7 @@
 from . import pyambit
 from .pyambit import TensorType, EigenvalueOrder, Tensor
 from .pyambit import initialize, finalize
+from .pyambit import MOSpace, SpinType
 
 from . import blocked_tensor
-from .blocked_tensor import MOSpace, SpinType, BlockedTensor
+from .blocked_tensor import BlockedTensor

--- a/lib/ambit/blocked_tensor.py
+++ b/lib/ambit/blocked_tensor.py
@@ -34,41 +34,6 @@ import copy
 import numbers
 import sys, traceback
 
-class SpinType:
-    AlphaSpin = 1
-    BetaSpin = 2
-    NoSpin = 3
-
-
-class MOSpace:
-    def __init__(self, name, mo_indices, mos, spin):
-        self.name = str(name)
-        self.mo_indices = pyambit.Indices.split(mo_indices)
-        self.mos = mos
-
-        if len(self.name) == 0:
-            raise RuntimeError("MOSpace: No name provided to MO space")
-
-        if len(mo_indices) == 0:
-            raise RuntimeError("MOSpace: No MO indices provided.")
-
-        if len(mos) == 0:
-            raise RuntimeError("MOSpace: No MOs provided.")
-
-        if SpinType.AlphaSpin <= spin <= SpinType.NoSpin:
-            self.spin = spin
-        else:
-            raise TypeError("Value of spin is invalid.")
-
-    def dim(self):
-        return len(self.mos)
-
-    def __str__(self):
-        msg = "\n  Orbital Space \"%s\"\n  MO Indices: {%s}\n  MO List: (%s)\n" % (
-        self.name, ','.join(map(str, self.mo_indices)), ','.join(map(str, self.mos)))
-        return msg
-
-
 class LabeledBlockedTensorProduct:
 
     def __init__(self, left, right):
@@ -368,7 +333,7 @@ class BlockedTensor:
 
         mo_space_idx = len(BlockedTensor.mo_spaces)
 
-        ms = MOSpace(name, mo_indices, mos, spin)
+        ms = pyambit.MOSpace(name, mo_indices, mos, spin)
 
         # Add the MOSpace object
         BlockedTensor.mo_spaces.append(ms)

--- a/src/blocked_tensor/blocked_tensor.cc
+++ b/src/blocked_tensor/blocked_tensor.cc
@@ -54,11 +54,13 @@ std::map<std::string, std::vector<size_t>> BlockedTensor::index_to_mo_spaces_;
 
 bool BlockedTensor::expert_mode_ = false;
 
+
 MOSpace::MOSpace(const std::string &name, const std::string &mo_indices,
                  std::vector<size_t> mos, SpinType spin)
     : name_(name), mo_indices_(indices::split(mo_indices)), mos_(mos),
       spin_(mos.size(), spin)
 {
+    common_init();
 }
 
 MOSpace::MOSpace(const std::string &name, const std::string &mo_indices,
@@ -69,6 +71,24 @@ MOSpace::MOSpace(const std::string &name, const std::string &mo_indices,
     {
         mos_.push_back(p_s.first);
         spin_.push_back(p_s.second);
+    }
+    common_init();
+}
+
+void MOSpace::common_init() const {
+    if (name_.size() == 0)
+    {
+        throw std::runtime_error("Empty name given to orbital space.");
+    }
+    if (mo_indices_.size() == 0)
+    {
+        throw std::runtime_error(
+            "No MO indices were specified for the MO space \"" + name_ + "\"");
+    }
+    if (mos_.size() == 0)
+    {
+        throw std::runtime_error(
+            "No MOs were specified for the MO space \"" + name_ + "\"");
     }
 }
 
@@ -88,15 +108,6 @@ void BlockedTensor::add_mo_space(const std::string &name,
                                  const std::string &mo_indices,
                                  std::vector<size_t> mos, SpinType spin)
 {
-    if (name.size() == 0)
-    {
-        throw std::runtime_error("Empty name given to orbital space.");
-    }
-    if (mo_indices.size() == 0)
-    {
-        throw std::runtime_error(
-            "No MO indices were specified for the MO space \"" + name + "\"");
-    }
     if (name_to_mo_space_.count(name) != 0)
     {
         throw std::runtime_error("The MO space \"" + name +
@@ -134,15 +145,6 @@ void BlockedTensor::add_mo_space(
     const std::string &name, const std::string &mo_indices,
     std::vector<std::pair<size_t, SpinType>> mo_spin)
 {
-    if (name.size() == 0)
-    {
-        throw std::runtime_error("Empty name given to orbital space.");
-    }
-    if (mo_indices.size() == 0)
-    {
-        throw std::runtime_error(
-            "No MO indices were specified for the MO space \"" + name + "\"");
-    }
     if (name_to_mo_space_.count(name) != 0)
     {
         throw std::runtime_error("The MO space \"" + name +

--- a/src/python/bindings.cc
+++ b/src/python/bindings.cc
@@ -32,6 +32,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
+#include <ambit/blocked_tensor.h>
 #include <ambit/tensor.h>
 #include <../tensor/indices.h>
 
@@ -148,6 +149,17 @@ PYBIND11_MODULE(pyambit, m)
         .def_static("permutation_order", &indices::permutation_order)
         .def_static("determine_contraction_result_from_indices",
              &indices::determine_contraction_result_from_indices);
+
+    py::enum_<SpinType>(m, "SpinType")
+        .value("AlphaSpin", SpinType::AlphaSpin)
+        .value("BetaSpin", SpinType::BetaSpin)
+        .value("NoSpin", SpinType::NoSpin)
+        .export_values();
+
+    py::class_<MOSpace>(m, "MOSpace")
+        .def(py::init<const std::string &, const std::string &, std::vector<size_t>, SpinType>())
+        .def("dim", &MOSpace::dim)
+        .def_property_readonly("name", &MOSpace::name);
 
     typedef const Indices &(LabeledTensor::*idx)() const;
     std::vector<double> &(Tensor::*data)() = &Tensor::data;

--- a/test/test_blocks.cc
+++ b/test/test_blocks.cc
@@ -2499,7 +2499,7 @@ int main(int argc, char *argv[])
                         "Testing adding orbital space with no indices (1)"),
         std::make_tuple(kException, test_add_mo_space_no_index2,
                         "Testing adding orbital space with no indices (2)"),
-        std::make_tuple(kPass, test_add_mo_space_no_mos,
+        std::make_tuple(kException, test_add_mo_space_no_mos,
                         "Testing adding orbital space with no orbital list"),
         std::make_tuple(kPass, test_block_creation1,
                         "Testing blocked tensor creation (1)"),


### PR DESCRIPTION
Gets rid of the MOSpace class and the SpinType `enum`. C side and Py side contradicted each other about whether having no MOs is acceptable, so I changed the C-side contract and left the Py-side contract intact: thou must have MOs. I can change this if needed.