### PR TITLE
Allow no MOs

### DIFF
--- a/lib/test_blocks.py
+++ b/lib/test_blocks.py
@@ -215,7 +215,6 @@ class TestBlocks(unittest.TestCase):
         ambit.BlockedTensor.add_mo_space("v", "a,b,c,d", [5,6,7,8,9], ambit.SpinType.AlphaSpin)
         ambit.BlockedTensor.add_composite_mo_space("g", "", ["o", "v"])
 
-    @unittest.expectedFailure
     def test_add_mo_space_no_mos(self):
         ambit.BlockedTensor.reset_mo_space()
         ambit.BlockedTensor.add_mo_space("o", "i,j,k,l", [], ambit.SpinType.AlphaSpin)

--- a/src/blocked_tensor/blocked_tensor.cc
+++ b/src/blocked_tensor/blocked_tensor.cc
@@ -85,11 +85,9 @@ void MOSpace::common_init() const {
         throw std::runtime_error(
             "No MO indices were specified for the MO space \"" + name_ + "\"");
     }
-    if (mos_.size() == 0)
-    {
-        throw std::runtime_error(
-            "No MOs were specified for the MO space \"" + name_ + "\"");
-    }
+    // No MOs specified for an MO space is permitted.
+    // Use Case: Frozen orbitals. These shouldn't show up in a tensor, but it's nice
+    //    to have explicitly accounted for them.
 }
 
 void MOSpace::print()

--- a/test/test_blocks.cc
+++ b/test/test_blocks.cc
@@ -2499,7 +2499,7 @@ int main(int argc, char *argv[])
                         "Testing adding orbital space with no indices (1)"),
         std::make_tuple(kException, test_add_mo_space_no_index2,
                         "Testing adding orbital space with no indices (2)"),
-        std::make_tuple(kException, test_add_mo_space_no_mos,
+        std::make_tuple(kPass, test_add_mo_space_no_mos,
                         "Testing adding orbital space with no orbital list"),
         std::make_tuple(kPass, test_block_creation1,
                         "Testing blocked tensor creation (1)"),


### PR DESCRIPTION
C and Py-side disagreed on whether an MO space with no MOs should be allowed. During my fixes, I synced them up so that the case of no MOs were banned for both. Forte doesn't like that, so now we're changing back to no MOs being allowed on both.