### PR TITLE
add const Tensor to ambit::BlockedTensor::block

### DIFF
--- a/include/ambit/blocked_tensor.h
+++ b/include/ambit/blocked_tensor.h
@@ -254,6 +254,9 @@ class BlockedTensor
     const Tensor block(const std::vector<size_t> &key) const;
     /// Return a Tensor object that corresponds to a given block key
     Tensor block(const std::string &indices);
+    /// Return a constant Tensor object that corresponds to a given block
+    /// key
+    const Tensor block(const std::string &indices) const;
 
     void set_block(const std::vector<size_t> &key, Tensor t);
     void set_block(const std::string &indices, Tensor t);

--- a/src/blocked_tensor/blocked_tensor.cc
+++ b/src/blocked_tensor/blocked_tensor.cc
@@ -505,6 +505,25 @@ Tensor BlockedTensor::block(const std::string &indices)
     return block(key);
 }
 
+const Tensor BlockedTensor::block(const std::string &indices) const
+{
+    std::vector<size_t> key;
+    for (const std::string &index : indices::split(indices))
+    {
+        if (name_to_mo_space_.count(index) != 0)
+        {
+            key.push_back(name_to_mo_space_[index]);
+        }
+        else
+        {
+            throw std::runtime_error(
+                "Cannot retrieve block " + indices + " of tensor " + name() +
+                ". The index " + index + " does not indentify a unique space");
+        }
+    }
+    return block(key);
+}
+
 void BlockedTensor::set_block(const std::string &indices, Tensor t)
 {
     std::vector<size_t> key;


### PR DESCRIPTION
This PR just adds `const Tensor block(const std::string &indices) const;`. I am not sure why `const Tensor block(const std::vector<size_t> &key) const;` was available before but not accepting `const std::string &indices`.