### PR TITLE
Fix compiler warning and error when including ambit.

### DIFF
--- a/cmake/FindTargetHDF5.cmake
+++ b/cmake/FindTargetHDF5.cmake
@@ -83,6 +83,11 @@ else()
     endif()
 endif()
 
+if (${PN}_VERSION MATCHES "^([0-9]+).([0-9]+).*$")
+    set(${PN}_VERSION_Mm "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}")
+endif()
+
+
 get_property(_ill TARGET tgt::hdf5 PROPERTY INTERFACE_LINK_LIBRARIES)
 get_property(_iid TARGET tgt::hdf5 PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 set(${PN}_MESSAGE "Found HDF5: ${_ill} (found version ${${PN}_VERSION})")

--- a/cmake/ambitConfig.cmake.in
+++ b/cmake/ambitConfig.cmake.in
@@ -83,7 +83,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 # check library dependency available
 include(CMakeFindDependencyMacro)
 if(NOT TARGET tgt::hdf5)
-    find_dependency(TargetHDF5 @TargetHDF5_VERSION@ EXACT)
+    find_dependency(TargetHDF5 @TargetHDF5_VERSION_Mm@)
 endif()
 if(NOT TARGET tgt::lapack)
     find_dependency(TargetLAPACK)

--- a/include/ambit/print.h
+++ b/include/ambit/print.h
@@ -36,12 +36,12 @@ namespace ambit
 {
 
 /// Print function. Only the master node is allowed to print to the screen.
-void print(const string &format, ...);
+void print(const string format, ...);
 
 /** Each process will print to their respective output file.
  *  The master process will print to both the screen and its output file.
  */
-void printn(const string &format, ...);
+void printn(const string format, ...);
 
 /** Increases printing column offset by increment.
  * @param increment the amount to increase indentation.

--- a/src/tensor/print.cc
+++ b/src/tensor/print.cc
@@ -55,7 +55,7 @@ void unindent(int decrement)
         indent_size = 0;
 }
 
-void print(const string &format, ...)
+void print(const string format, ...)
 {
     if (ambit::settings::rank == 0)
     {
@@ -67,7 +67,7 @@ void print(const string &format, ...)
     }
 }
 
-void printn(const string &format, ...)
+void printn(const string format, ...)
 {
     for (int proc = 0; proc < settings::nprocess; proc++)
     {

--- a/src/tensor/sliced_tensor.cc
+++ b/src/tensor/sliced_tensor.cc
@@ -59,12 +59,13 @@ SlicedTensor::SlicedTensor(Tensor T, const IndexRange &range, double factor)
 
 void SlicedTensor::operator=(const SlicedTensor &rhs)
 {
-    if (T() == rhs.T())
+    if (T() == rhs.T()) {
         if (range_ == rhs.range_ and factor_ == rhs.factor_) {
             return; // No work to do.
         } else {
             throw std::runtime_error("Non-trivial self-assignment is not allowed.");
         }
+    }
     if (T_.rank() != rhs.T().rank())
         throw std::runtime_error("Sliced tensors do not have same rank");
     T_.slice(rhs.T(), range_, rhs.range_, rhs.factor_, 0.0);

--- a/src/tensor/timer.cc
+++ b/src/tensor/timer.cc
@@ -109,13 +109,11 @@ void print_timer_info(TimerDetail *timer)
     char buffer[512];
     if (timer != root)
     {
+        auto time = std::chrono::duration_cast<std::chrono::milliseconds>(timer->total_time).count();
         snprintf(buffer, 512, "%lld ms : %lld calls : %lld ms per call : ",
-                 std::chrono::duration_cast<std::chrono::milliseconds>(
-                     timer->total_time),
-                 timer->total_calls,
-                 std::chrono::duration_cast<std::chrono::milliseconds>(
-                     timer->total_time) /
-                     timer->total_calls);
+                 time,
+                 static_cast<long long>(timer->total_calls),
+                 time / timer->total_calls);
         print("%s%*s%s\n", buffer,
               //              60 - ambit::current_indent() - strlen(buffer),
               60 - strlen(buffer), "", timer->name.c_str());


### PR DESCRIPTION
Fixes an error when other programs (like Forte) tried to include ambit. ambit's files could say to include an invalid cmake version.

Also fixes many compiler warnings.